### PR TITLE
feat(register): hook up the register page

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -7,9 +7,11 @@ import { bootstrap }        from 'angular2/bootstrap';
 import { HTTP_PROVIDERS }   from 'angular2/http';
 import { ROUTER_PROVIDERS } from 'angular2/router';
 
+import { ApiService }   from './services/api';
 import { AppComponent } from './components/app';
 
 bootstrap(AppComponent, [
+  ApiService,
   HTTP_PROVIDERS,
   ROUTER_PROVIDERS
 ]);

--- a/app/classes/session.ts
+++ b/app/classes/session.ts
@@ -1,0 +1,9 @@
+export class Session {
+
+  public token: string;
+
+  constructor (params) {
+    this.token = params.token;
+  }
+
+}

--- a/app/classes/user.ts
+++ b/app/classes/user.ts
@@ -1,0 +1,35 @@
+const FRIEND_CODE_REGEX = /(\d{4})(?=\d)/g;
+
+export class User {
+
+  public id: number;
+  public username: string;
+  public password: string;
+  public password_confirm: string;
+
+  private _friend_code: string;
+
+  public get friend_code (): string {
+    return this._friend_code;
+  };
+
+  public set friend_code (_friend_code: string) {
+    this._friend_code = _friend_code && _friend_code.replace(FRIEND_CODE_REGEX, '$1-');
+  }
+
+  constructor (params) {
+    this.id = params.id;
+    this.username = params.username;
+    this.friend_code = params.friend_code;
+  }
+
+  public toJSON (): Object {
+    return {
+      friend_code: this.friend_code || undefined,
+      id: this.id,
+      password: this.password,
+      username: this.username
+    };
+  }
+
+}

--- a/app/components/app.ts
+++ b/app/components/app.ts
@@ -5,12 +5,14 @@ import { HomeComponent }     from './home';
 import { LoginComponent }    from './login';
 import { NavComponent }      from './nav';
 import { RegisterComponent } from './register';
+import { SessionService }    from '../services/session';
 import { TrackerComponent }  from './tracker';
 
 const HTML = require('../views/app.html');
 
 @Component({
   directives: [NavComponent, RouterOutlet],
+  providers: [SessionService],
   selector: 'app',
   template: HTML
 })
@@ -20,4 +22,12 @@ const HTML = require('../views/app.html');
   { component: RegisterComponent, name: 'Register', path: '/register' },
   { component: TrackerComponent,  name: 'Tracker',  path: '/tracker' }
 ])
-export class AppComponent {}
+export class AppComponent {
+
+  public _session: SessionService;
+
+  constructor (_session: SessionService) {
+    this._session = _session;
+  }
+
+}

--- a/app/components/nav.ts
+++ b/app/components/nav.ts
@@ -1,9 +1,22 @@
-import { Component } from 'angular2/core';
+import { Component }  from 'angular2/core';
+import { RouterLink } from 'angular2/router';
+
+import { User } from '../classes/user';
 
 const HTML = require('../views/nav.html');
 
 @Component({
+  directives: [RouterLink],
+  inputs: ['user'],
   selector: 'nav',
   template: HTML
 })
-export class NavComponent {}
+export class NavComponent {
+
+  public user: User;
+
+  public signOut () {
+    localStorage.removeItem('token');
+  }
+
+}

--- a/app/components/register.ts
+++ b/app/components/register.ts
@@ -1,19 +1,43 @@
-import { Component }  from 'angular2/core';
-import { RouterLink } from 'angular2/router';
-import { Title }      from 'angular2/platform/browser';
+import { Component }          from 'angular2/core';
+import { Router, RouterLink } from 'angular2/router';
+import { Title }              from 'angular2/platform/browser';
+
+import { User }        from '../classes/user';
+import { UserService } from '../services/user';
 
 const HTML = require('../views/register.html');
 
 @Component({
   directives: [RouterLink],
-  providers: [Title],
+  providers: [Title, UserService],
   selector: 'register',
   template: HTML
 })
 export class RegisterComponent {
 
-  constructor (_title: Title) {
+  public error: string = null;
+  public user: User = new User({});
+
+  private _router: Router;
+  private _user: UserService;
+
+  constructor (_router: Router, _title: Title, _user: UserService) {
+    this._router = _router;
+    this._user = _user;
     _title.setTitle('Pokédex Tracker');
+  }
+
+  public createUser (payload: User) {
+    if (payload.password === payload.password_confirm) {
+      this.error = null;
+    } else {
+      return this.error = 'passwords need to match';
+    }
+
+    this._user.create(payload)
+    .then((session) => localStorage.setItem('token', session.token))
+    .then(() => this._router.navigate(['Home']))
+    .catch((err) => this.error = err.message);
   }
 
 }

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -19,11 +19,11 @@ export class TrackerComponent {
   public active: Pokemon;
   public pokemon: Pokemon[] = [];
 
-  constructor (_pokemonService: PokemonService, _title: Title) {
+  constructor (_pokemon: PokemonService, _title: Title) {
     _title.setTitle('My Pokédex Tracker');
 
-    _pokemonService.list()
-    .subscribe((pokemon: Pokemon[]) => {
+    _pokemon.list()
+    .then((pokemon: Pokemon[]) => {
       this.pokemon = pokemon;
       this.active = pokemon[0];
     });

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -1,0 +1,39 @@
+import { Injectable }                    from 'angular2/core';
+import { Headers, Http, RequestOptions } from 'angular2/http';
+
+@Injectable()
+export class ApiService {
+
+  private url = 'https://api.pokedextracker.com';
+  private _http: Http;
+
+  public get options (): RequestOptions {
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    const token = localStorage.getItem('token');
+
+    if (token) {
+      headers.append('Authorization', `Bearer ${token}`);
+    }
+
+    return new RequestOptions({ headers });
+  }
+
+  constructor (_http: Http) {
+    this._http = _http;
+  }
+
+  public get (endpoint: string): Promise<Object> {
+    return this._http.get(this.url + endpoint, this.options)
+    .toPromise()
+    .then((res) => res.json())
+    .catch((err) => Promise.reject(err.json().error));
+  }
+
+  public post (endpoint: string, payload: Object): Promise<Object> {
+    return this._http.post(this.url + endpoint, JSON.stringify(payload), this.options)
+    .toPromise()
+    .then((res) => res.json())
+    .catch((err) => Promise.reject(err.json().error));
+  }
+
+}

--- a/app/services/pokemon.ts
+++ b/app/services/pokemon.ts
@@ -1,21 +1,21 @@
 import { Injectable } from 'angular2/core';
 import { Http }       from 'angular2/http';
-import { Observable } from 'rxjs/Rx';
 
-import { Pokemon } from '../classes/pokemon';
+import { ApiService } from './api';
+import { Pokemon }    from '../classes/pokemon';
 
 @Injectable()
 export class PokemonService {
 
-  private _http: Http;
+  private _api: ApiService;
 
-  constructor (_http: Http) {
-    this._http = _http;
+  constructor (_api: ApiService) {
+    this._api = _api;
   }
 
-  public list (): Observable<Pokemon[]> {
-    return this._http.get('https://api.pokedextracker.com/pokemon')
-    .map((res) => res.json().map((p) => new Pokemon(p)));
+  public list (): Promise<Pokemon[]> {
+    return this._api.get('/pokemon')
+    .then((pokemon: Array<Object>) => pokemon.map((p) => new Pokemon(p)));
   }
 
 }

--- a/app/services/session.ts
+++ b/app/services/session.ts
@@ -1,0 +1,21 @@
+import { Injectable } from 'angular2/core';
+
+import { User } from '../classes/user';
+
+@Injectable()
+export class SessionService {
+
+  public get loggedIn (): boolean {
+    return Boolean(localStorage.getItem('token'));
+  }
+
+  public get user (): User {
+    if (!this.loggedIn) {
+      return null;
+    }
+    const payload = JSON.parse(atob(localStorage.getItem('token').split('.')[1]));
+
+    return new User(payload);
+  }
+
+}

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,0 +1,20 @@
+import { Injectable } from 'angular2/core';
+
+import { ApiService } from './api';
+import { Session }    from '../classes/session';
+
+@Injectable()
+export class UserService {
+
+  private _api: ApiService;
+
+  constructor (_api: ApiService) {
+    this._api = _api;
+  }
+
+  public create (payload: Object): Promise<Session> {
+    return this._api.post('/users', payload)
+    .then((session: Object) => new Session(session));
+  }
+
+}

--- a/app/views/app.html
+++ b/app/views/app.html
@@ -1,2 +1,2 @@
-<nav></nav>
+<nav [user]="_session.user"></nav>
 <router-outlet></router-outlet>

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -1,2 +1,3 @@
-<a href="/">Pokédex Tracker</a>
-<a href="">Sign Out</a>
+<a [routerLink]="['Home']">Pokédex Tracker</a>
+<a *ngIf="user" href="">{{user.username}}</a>
+<a *ngIf="user" (click)="signOut()">Sign Out</a>

--- a/app/views/register.html
+++ b/app/views/register.html
@@ -1,25 +1,25 @@
-<form>
-  <div class="form-alert">
-    username must be less than 20 characters
+<form (ngSubmit)="createUser(user)">
+  <div *ngIf="error" class="form-alert">
+    {{error}}
   </div>
   <div class="form-group">
     <label for="username">Username</label>
-    <input id="username" type="text" required placeholder="ashketchum10">
+    <input [(ngModel)]="user.username" id="username" type="text" required placeholder="ashketchum10">
     <i class="fa fa-asterisk"></i>
   </div>
   <div class="form-group">
     <label for="password">Password</label>
-    <input id="password" type="password" required placeholder="••••••••••••">
+    <input [(ngModel)]="user.password" id="password" type="password" required placeholder="••••••••••••">
     <i class="fa fa-asterisk"></i>
   </div>
   <div class="form-group">
     <label for="password_confirm">Confirm Password</label>
-    <input id="password_confirm" type="password" required placeholder="••••••••••••">
+    <input [(ngModel)]="user.password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••">
     <i class="fa fa-asterisk"></i>
   </div>
   <div class="form-group">
     <label for="friend_code">Friend Code</label>
-    <input id="friend_code" type="text" placeholder="0000-0000-0000">
+    <input [(ngModel)]="user.friend_code" id="friend_code" type="text" placeholder="0000-0000-0000">
   </div>
   <button type="submit" class="btn">Let's go! <i class="fa fa-long-arrow-right"></i></button>
   <p>Already have an account? <a class="link" [routerLink]="['Login']">Login here</a>!</p>

--- a/tslint.json
+++ b/tslint.json
@@ -64,8 +64,6 @@
     ],
     "variable-name": [
       true,
-      "check-format",
-      "allow-leading-underscore",
       "ban-keywords"
     ],
     "whitespace": [


### PR DESCRIPTION
ʕʘ̅͜ʘ̅ʔ

### notes

keep in might this is only for registration, nothing else, which means that even if the registration goes through successfully, you won't actually see any signs that you're logged in. to make sure it worked, you can open up the inspector, head to the Resources tab, expand the Local Storage section in the left sidebar, click http://localhost:8080 and you should see `token` and then a string that starts with `eyJ0eX`:

<img width="567" alt="screen shot 2016-03-22 at 10 43 59 pm" src="https://cloud.githubusercontent.com/assets/2454505/13976764/4d349f7c-f080-11e5-8600-0935dc321cf1.png">

if you want to log out, just select the `token`, delete it, and refresh.

also, since we have no staging env, lemme know after you're done testing so I can purge the db.

### things to test

- error messages
- password confirm
- optional friend code
- redirect on success

fixes #24 
fixes #29 