### PR TITLE
feat(routes): finalize routing

### DIFF
--- a/app/components/app.ts
+++ b/app/components/app.ts
@@ -3,31 +3,18 @@ import { RouteConfig, RouterOutlet } from 'angular2/router';
 
 import { HomeComponent }     from './home';
 import { LoginComponent }    from './login';
-import { NavComponent }      from './nav';
 import { RegisterComponent } from './register';
-import { SessionService }    from '../services/session';
 import { TrackerComponent }  from './tracker';
 
-const HTML = require('../views/app.html');
-
 @Component({
-  directives: [NavComponent, RouterOutlet],
-  providers: [SessionService],
+  directives: [RouterOutlet],
   selector: 'app',
-  template: HTML
+  template: '<router-outlet></router-outlet>'
 })
 @RouteConfig([
   { component: HomeComponent,     name: 'Home',     path: '/' },
   { component: LoginComponent,    name: 'Login',    path: '/login' },
   { component: RegisterComponent, name: 'Register', path: '/register' },
-  { component: TrackerComponent,  name: 'Tracker',  path: '/tracker' }
+  { component: TrackerComponent,  name: 'Tracker',  path: '/u/:username' }
 ])
-export class AppComponent {
-
-  public _session: SessionService;
-
-  constructor (_session: SessionService) {
-    this._session = _session;
-  }
-
-}
+export class AppComponent {}

--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -4,13 +4,14 @@ import { BoxComponent }    from './box';
 import { GroupPipe }       from '../pipes/group';
 import { HeaderComponent } from './header';
 import { Pokemon }         from '../classes/pokemon';
+import { User }            from '../classes/user';
 
 const HTML = require('../views/dex.html');
 
 @Component({
   directives: [HeaderComponent, BoxComponent],
   events: ['pokemonHover'],
-  inputs: ['pokemon'],
+  inputs: ['pokemon', 'user'],
   pipes: [GroupPipe],
   selector: 'dex',
   template: HTML
@@ -18,6 +19,7 @@ const HTML = require('../views/dex.html');
 export class DexComponent {
 
   public pokemon: Pokemon[];
+  public user: User;
 
   public pokemonHover = new EventEmitter<Pokemon>();
 

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -1,9 +1,16 @@
 import { Component } from 'angular2/core';
 
+import { User } from '../classes/user';
+
 const HTML = require('../views/header.html');
 
 @Component({
+  inputs: ['user'],
   selector: 'header',
   template: HTML
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+
+  public user: User;
+
+}

--- a/app/components/home.ts
+++ b/app/components/home.ts
@@ -1,17 +1,34 @@
-import { Component } from 'angular2/core';
-import { Title }     from 'angular2/platform/browser';
+import { Component, OnInit } from 'angular2/core';
+import { Router }            from 'angular2/router';
+import { Title }             from 'angular2/platform/browser';
+
+import { SessionService } from '../services/session';
 
 const HTML = require('../views/home.html');
 
 @Component({
-  providers: [Title],
+  providers: [SessionService, Title],
   selector: 'home',
   template: HTML
 })
-export class HomeComponent {
+export class HomeComponent implements OnInit {
 
-  constructor (_title: Title) {
-    _title.setTitle('Pokédex Tracker');
+  private _router: Router;
+  private _session: SessionService;
+  private _title: Title;
+
+  constructor (_router: Router, _session: SessionService, _title: Title) {
+    this._router = _router;
+    this._session = _session;
+    this._title = _title;
+  }
+
+  public ngOnInit () {
+    if (this._session.user) {
+      return this._router.navigate(['Tracker', { username: this._session.user.username }]);
+    }
+
+    this._title.setTitle('Pokédex Tracker');
   }
 
 }

--- a/app/components/login.ts
+++ b/app/components/login.ts
@@ -1,19 +1,37 @@
-import { Component }  from 'angular2/core';
-import { RouterLink } from 'angular2/router';
-import { Title }      from 'angular2/platform/browser';
+import { Component, OnInit }  from 'angular2/core';
+import { Router, RouterLink } from 'angular2/router';
+import { Title }              from 'angular2/platform/browser';
+
+import { NavComponent }   from './nav';
+import { SessionService } from '../services/session';
 
 const HTML = require('../views/login.html');
 
 @Component({
-  directives: [RouterLink],
-  providers: [Title],
+  directives: [NavComponent, RouterLink],
+  providers: [SessionService, Title],
   selector: 'login',
   template: HTML
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
 
-  constructor (_title: Title) {
-    _title.setTitle('Pokédex Tracker');
+  public _session: SessionService;
+
+  private _router: Router;
+  private _title: Title;
+
+  constructor (_router: Router, _session: SessionService, _title: Title) {
+    this._router = _router;
+    this._session = _session;
+    this._title = _title;
+  }
+
+  public ngOnInit () {
+    if (this._session.user) {
+      return this._router.navigate(['Tracker', { username: this._session.user.username }]);
+    }
+
+    this._title.setTitle('Login | Pokédex Tracker');
   }
 
 }

--- a/app/components/register.ts
+++ b/app/components/register.ts
@@ -1,30 +1,43 @@
-import { Component }          from 'angular2/core';
+import { Component, OnInit }  from 'angular2/core';
 import { Router, RouterLink } from 'angular2/router';
 import { Title }              from 'angular2/platform/browser';
 
-import { User }        from '../classes/user';
-import { UserService } from '../services/user';
+import { NavComponent }   from './nav';
+import { SessionService } from '../services/session';
+import { User }           from '../classes/user';
+import { UserService }    from '../services/user';
 
 const HTML = require('../views/register.html');
 
 @Component({
-  directives: [RouterLink],
-  providers: [Title, UserService],
+  directives: [NavComponent, RouterLink],
+  providers: [SessionService, Title, UserService],
   selector: 'register',
   template: HTML
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
 
   public error: string = null;
+  public _session: SessionService;
   public user: User = new User({});
 
   private _router: Router;
+  private _title: Title;
   private _user: UserService;
 
-  constructor (_router: Router, _title: Title, _user: UserService) {
+  constructor (_router: Router, _session: SessionService, _title: Title, _user: UserService) {
     this._router = _router;
+    this._session = _session;
+    this._title = _title;
     this._user = _user;
-    _title.setTitle('Pokédex Tracker');
+  }
+
+  public ngOnInit () {
+    if (this._session.user) {
+      return this._router.navigate(['Tracker', { username: this._session.user.username }]);
+    }
+
+    this._title.setTitle('Register | Pokédex Tracker');
   }
 
   public createUser (payload: User) {
@@ -36,7 +49,7 @@ export class RegisterComponent {
 
     this._user.create(payload)
     .then((session) => localStorage.setItem('token', session.token))
-    .then(() => this._router.navigate(['Home']))
+    .then(() => this._router.navigate(['Tracker', { username: this._session.user.username }]))
     .catch((err) => this.error = err.message);
   }
 

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -1,29 +1,54 @@
-import { Component } from 'angular2/core';
-import { Title }     from 'angular2/platform/browser';
+import { Component, OnInit } from 'angular2/core';
+import { RouteParams }       from 'angular2/router';
+import { Title }             from 'angular2/platform/browser';
 
 import { DexComponent }   from './dex';
 import { InfoComponent }  from './info';
+import { NavComponent }   from './nav';
 import { Pokemon }        from '../classes/pokemon';
 import { PokemonService } from '../services/pokemon';
+import { SessionService } from '../services/session';
+import { User }           from '../classes/user';
+import { UserService }    from '../services/user';
 
 const HTML = require('../views/tracker.html');
 
 @Component({
-  directives: [DexComponent, InfoComponent],
-  providers: [PokemonService, Title],
+  directives: [DexComponent, InfoComponent, NavComponent],
+  providers: [PokemonService, SessionService, Title, UserService],
   selector: 'tracker',
   template: HTML
 })
-export class TrackerComponent {
+export class TrackerComponent implements OnInit {
 
   public active: Pokemon;
   public pokemon: Pokemon[] = [];
+  public _session: SessionService;
+  public user: User;
 
-  constructor (_pokemon: PokemonService, _title: Title) {
-    _title.setTitle('My Pokédex Tracker');
+  private _pokemon: PokemonService;
+  private _routeParams: RouteParams;
+  private _title: Title;
+  private _user: UserService;
 
-    _pokemon.list()
-    .then((pokemon: Pokemon[]) => {
+  constructor (_pokemon: PokemonService, _routeParams: RouteParams, _session: SessionService, _title: Title, _user: UserService) {
+    this._pokemon = _pokemon;
+    this._routeParams = _routeParams;
+    this._session = _session;
+    this._title = _title;
+    this._user = _user;
+  }
+
+  public ngOnInit () {
+    this._user.retrieve(this._routeParams.get('username'))
+    .then((user) => {
+      this._title.setTitle(`${this._routeParams.get('username')}'s Pokédex Tracker`);
+
+      this.user = user;
+
+      return this._pokemon.list();
+    })
+    .then((pokemon) => {
       this.pokemon = pokemon;
       this.active = pokemon[0];
     });

--- a/app/services/session.ts
+++ b/app/services/session.ts
@@ -5,17 +5,14 @@ import { User } from '../classes/user';
 @Injectable()
 export class SessionService {
 
-  public get loggedIn (): boolean {
-    return Boolean(localStorage.getItem('token'));
-  }
-
   public get user (): User {
-    if (!this.loggedIn) {
+    const token = localStorage.getItem('token');
+
+    if (!token) {
       return null;
     }
-    const payload = JSON.parse(atob(localStorage.getItem('token').split('.')[1]));
 
-    return new User(payload);
+    return new User(JSON.parse(atob(token.split('.')[1])));
   }
 
 }

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -2,6 +2,7 @@ import { Injectable } from 'angular2/core';
 
 import { ApiService } from './api';
 import { Session }    from '../classes/session';
+import { User }       from '../classes/user';
 
 @Injectable()
 export class UserService {
@@ -12,9 +13,14 @@ export class UserService {
     this._api = _api;
   }
 
+  public retrieve (username: string): Promise<User> {
+    return this._api.get(`/users/${username}`)
+    .then((user) => new User(user));
+  }
+
   public create (payload: Object): Promise<Session> {
     return this._api.post('/users', payload)
-    .then((session: Object) => new Session(session));
+    .then((session) => new Session(session));
   }
 
 }

--- a/app/views/app.html
+++ b/app/views/app.html
@@ -1,2 +1,0 @@
-<nav [user]="_session.user"></nav>
-<router-outlet></router-outlet>

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,2 +1,2 @@
-<header></header>
+<header [user]="user"></header>
 <box *ngFor="#p of pokemon | GroupPipe : 30" (pokemonHover)="pokemonHover.emit($event)" [pokemon]="p"></box>

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -1,5 +1,5 @@
-<h1>Cabrioles's Living Dex</h1>
-<h2>FC: <span class="fc-missing">0533-6415-2774</span></h2>
+<h1>{{user.username}}'s Living Dex</h1>
+<h2>FC: <span [class.fc-missing]="!user.friend_code">{{user.friend_code || 'XXXX-XXXX-XXXX'}}</span></h2>
 
 <div class="region-filter">
   <div class="active">National</div>

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -1,3 +1,4 @@
+<nav [user]="_session.user"></nav>
 <form>
   <div class="form-alert">
     username not found

--- a/app/views/register.html
+++ b/app/views/register.html
@@ -1,3 +1,4 @@
+<nav [user]="_session.user"></nav>
 <form (ngSubmit)="createUser(user)">
   <div *ngIf="error" class="form-alert">
     {{error}}

--- a/app/views/tracker.html
+++ b/app/views/tracker.html
@@ -1,2 +1,3 @@
-<dex (pokemonHover)="active = $event" [pokemon]="pokemon"></dex>
+<nav [user]="_session.user"></nav>
+<dex *ngIf="user" (pokemonHover)="active = $event" [pokemon]="pokemon" [user]="user"></dex>
 <info [pokemon]="active"></info>


### PR DESCRIPTION
ヘ(￣ω￣ヘ)

### what
* moved nav down to login, register, and tracker components, removing it from home
* if logged in, redirect from home, login, and register to your tracker page
* change from `/tracker` -> `/u/:username` and load correct basic info (no captures yet) of the user

### notes
* this does not handle user 404's. that will be handled in #43
* by moving nav, it messed up the flexbox configuration, so that needs to be fixed. i tried fixing it and other things broke so i'll leave that to you :)
* when a tracker page is loading, i'm hiding the entire dex component (to simulate loading and because it'll err otherwise), causing some weird stuff (the info component starts at the top). when you add the loading gif, that'll be the time to fix that
* the way it's set up right now, it would be possible to have multiple loading states (show the header after the user is done loading, then show the pokemon, then show the captures, etc). i don't know if that's desired or if you just wanna have one "loading state" that ends when everything is done loading. what do you think?

fixes #30 
fixes #40 