### PR TITLE
feat(captures): load, create, and delete captures

### DIFF
--- a/app/classes/capture.ts
+++ b/app/classes/capture.ts
@@ -1,0 +1,15 @@
+import { Pokemon } from './pokemon';
+
+export class Capture {
+
+  public user_id: number;
+  public pokemon: Pokemon;
+  public captured: boolean;
+
+  constructor (params) {
+    this.user_id = params.user_id;
+    this.pokemon = new Pokemon(params.pokemon);
+    this.captured = params.captured;
+  }
+
+}

--- a/app/components/box.ts
+++ b/app/components/box.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter } from 'angular2/core';
 
+import { Capture }          from '../classes/capture';
 import { NumberPipe }       from '../pipes/number';
-import { Pokemon }          from '../classes/pokemon';
 import { PokemonComponent } from './pokemon';
 
 const HTML = require('../views/box.html');
@@ -9,21 +9,21 @@ const HTML = require('../views/box.html');
 @Component({
   directives: [PokemonComponent],
   events: ['pokemonHover'],
-  inputs: ['pokemon'],
+  inputs: ['captures'],
   pipes: [NumberPipe],
   selector: 'box',
   template: HTML
 })
 export class BoxComponent {
 
-  public pokemon: Pokemon[];
+  public captures: Capture[];
 
-  public pokemonHover = new EventEmitter<Pokemon>();
+  public pokemonHover = new EventEmitter<Capture>();
 
   private boxSize = 30;
 
   public get empties (): Object[] {
-    return new Array(this.boxSize - this.pokemon.length);
+    return new Array(this.boxSize - this.captures.length);
   }
 
 }

--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -1,9 +1,9 @@
 import { Component, EventEmitter } from 'angular2/core';
 
 import { BoxComponent }    from './box';
+import { Capture }         from '../classes/capture';
 import { GroupPipe }       from '../pipes/group';
 import { HeaderComponent } from './header';
-import { Pokemon }         from '../classes/pokemon';
 import { User }            from '../classes/user';
 
 const HTML = require('../views/dex.html');
@@ -11,16 +11,16 @@ const HTML = require('../views/dex.html');
 @Component({
   directives: [HeaderComponent, BoxComponent],
   events: ['pokemonHover'],
-  inputs: ['pokemon', 'user'],
+  inputs: ['captures', 'user'],
   pipes: [GroupPipe],
   selector: 'dex',
   template: HTML
 })
 export class DexComponent {
 
-  public pokemon: Pokemon[];
+  public captures: Capture[];
   public user: User;
 
-  public pokemonHover = new EventEmitter<Pokemon>();
+  public pokemonHover = new EventEmitter<Capture>();
 
 }

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -1,16 +1,23 @@
 import { Component } from 'angular2/core';
 
-import { User } from '../classes/user';
+import { Capture } from '../classes/capture';
+import { User }    from '../classes/user';
 
 const HTML = require('../views/header.html');
 
 @Component({
-  inputs: ['user'],
+  inputs: ['captures', 'user'],
   selector: 'header',
   template: HTML
 })
 export class HeaderComponent {
 
+  public captures: Capture[];
+  public dropdown: boolean = false;
   public user: User;
+
+  public get caught () {
+    return this.captures.filter((capture) => capture.captured).length;
+  }
 
 }

--- a/app/components/info.ts
+++ b/app/components/info.ts
@@ -1,18 +1,18 @@
 import { Component } from 'angular2/core';
 
+import { Capture }    from '../classes/capture';
 import { NumberPipe } from '../pipes/number';
-import { Pokemon }    from '../classes/pokemon';
 
 const HTML = require('../views/info.html');
 
 @Component({
-  inputs: ['pokemon'],
+  inputs: ['capture'],
   pipes: [NumberPipe],
   selector: 'info',
   template: HTML
 })
 export class InfoComponent {
 
-  public pokemon: Pokemon;
+  public capture: Capture;
 
 }

--- a/app/components/pokemon.ts
+++ b/app/components/pokemon.ts
@@ -1,21 +1,47 @@
 import { Component, EventEmitter } from 'angular2/core';
 
-import { NumberPipe } from '../pipes/number';
-import { Pokemon }    from '../classes/pokemon';
+import { Capture }        from '../classes/capture';
+import { CaptureService } from '../services/capture';
+import { NumberPipe }     from '../pipes/number';
+import { SessionService } from '../services/session';
 
 const HTML = require('../views/pokemon.html');
 
 @Component({
   events: ['pokemonHover'],
-  inputs: ['pokemon'],
+  inputs: ['capture'],
   pipes: [NumberPipe],
   selector: 'pokemon',
   template: HTML
 })
 export class PokemonComponent {
 
-  public pokemon: Pokemon;
+  public capture: Capture;
 
-  public pokemonHover = new EventEmitter<Pokemon>();
+  public pokemonHover = new EventEmitter<Capture>();
+
+  private _capture: CaptureService;
+  private _session: SessionService;
+
+  constructor (_capture: CaptureService, _session: SessionService) {
+    this._capture = _capture;
+    this._session = _session;
+  }
+
+  public toggle () {
+    if (!this._session.user || this._session.user.id !== this.capture.user_id) {
+      return;
+    }
+
+    const payload = { pokemon: this.capture.pokemon.national_id };
+
+    if (this.capture.captured) {
+      this._capture.delete(payload)
+      .then(() => this.capture.captured = false);
+    } else {
+      this._capture.create(payload)
+      .then(() => this.capture.captured = true);
+    }
+  }
 
 }

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -2,11 +2,11 @@ import { Component, OnInit } from 'angular2/core';
 import { RouteParams }       from 'angular2/router';
 import { Title }             from 'angular2/platform/browser';
 
+import { Capture }        from '../classes/capture';
+import { CaptureService } from '../services/capture';
 import { DexComponent }   from './dex';
 import { InfoComponent }  from './info';
 import { NavComponent }   from './nav';
-import { Pokemon }        from '../classes/pokemon';
-import { PokemonService } from '../services/pokemon';
 import { SessionService } from '../services/session';
 import { User }           from '../classes/user';
 import { UserService }    from '../services/user';
@@ -15,24 +15,25 @@ const HTML = require('../views/tracker.html');
 
 @Component({
   directives: [DexComponent, InfoComponent, NavComponent],
-  providers: [PokemonService, SessionService, Title, UserService],
+  providers: [CaptureService, SessionService, Title, UserService],
   selector: 'tracker',
   template: HTML
 })
 export class TrackerComponent implements OnInit {
 
-  public active: Pokemon;
-  public pokemon: Pokemon[] = [];
+  public active: Capture;
+  public captures: Capture[] = [];
+  public loading: boolean = true;
   public _session: SessionService;
   public user: User;
 
-  private _pokemon: PokemonService;
+  private _capture: CaptureService;
   private _routeParams: RouteParams;
   private _title: Title;
   private _user: UserService;
 
-  constructor (_pokemon: PokemonService, _routeParams: RouteParams, _session: SessionService, _title: Title, _user: UserService) {
-    this._pokemon = _pokemon;
+  constructor (_capture: CaptureService, _routeParams: RouteParams, _session: SessionService, _title: Title, _user: UserService) {
+    this._capture = _capture;
     this._routeParams = _routeParams;
     this._session = _session;
     this._title = _title;
@@ -46,11 +47,12 @@ export class TrackerComponent implements OnInit {
 
       this.user = user;
 
-      return this._pokemon.list();
+      return this._capture.list({ user: user.id });
     })
-    .then((pokemon) => {
-      this.pokemon = pokemon;
-      this.active = pokemon[0];
+    .then((captures) => {
+      this.captures = captures;
+      this.active = captures[0];
+      this.loading = false;
     });
   }
 

--- a/app/pipes/group.ts
+++ b/app/pipes/group.ts
@@ -3,11 +3,11 @@ import { Pipe } from 'angular2/core';
 @Pipe({ name: 'GroupPipe' })
 export class GroupPipe {
 
-  public transform (pokemon, size) {
-    return pokemon.reduce((acc, p) => {
-      const box = Math.ceil(p.national_id / size) - 1;
-      acc[box] = acc[box] || [];
-      acc[box].push(p);
+  public transform (arr, [size]) {
+    return arr.reduce((acc, item, i) => {
+      const group = Math.ceil((i + 1) / size) - 1;
+      acc[group] = acc[group] || [];
+      acc[group].push(item);
       return acc;
     }, []);
   }

--- a/app/pipes/number.ts
+++ b/app/pipes/number.ts
@@ -3,7 +3,7 @@ import { Pipe } from 'angular2/core';
 @Pipe({ name: 'NumberPipe' })
 export class NumberPipe {
 
-  public transform (n, width) {
+  public transform (n, [width]) {
     n = n + '';
 
     return n.length >= width ? n : new Array(width - n.length + 1).join('0') + n;

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -1,5 +1,5 @@
-import { Injectable }                    from 'angular2/core';
-import { Headers, Http, RequestOptions } from 'angular2/http';
+import { Injectable }                                     from 'angular2/core';
+import { Headers, Http, RequestOptions, URLSearchParams } from 'angular2/http';
 
 @Injectable()
 export class ApiService {
@@ -22,15 +22,31 @@ export class ApiService {
     this._http = _http;
   }
 
-  public get (endpoint: string): Promise<Object> {
-    return this._http.get(this.url + endpoint, this.options)
+  public get (endpoint: string, params: Object = {}): Promise<Object> {
+    const options = this.options;
+    options.search = new URLSearchParams();
+    for (let key in params) {
+      options.search.set(key, params[key]);
+    }
+
+    return this._http.get(this.url + endpoint, options)
     .toPromise()
     .then((res) => res.json())
     .catch((err) => Promise.reject(err.json().error));
   }
 
-  public post (endpoint: string, payload: Object): Promise<Object> {
+  public post (endpoint: string, payload: Object = {}): Promise<Object> {
     return this._http.post(this.url + endpoint, JSON.stringify(payload), this.options)
+    .toPromise()
+    .then((res) => res.json())
+    .catch((err) => Promise.reject(err.json().error));
+  }
+
+  public delete (endpoint: string, payload: Object = {}): Promise<Object> {
+    const options = this.options;
+    options.body = JSON.stringify(payload);
+
+    return this._http.delete(this.url + endpoint, options)
     .toPromise()
     .then((res) => res.json())
     .catch((err) => Promise.reject(err.json().error));

--- a/app/services/capture.ts
+++ b/app/services/capture.ts
@@ -1,0 +1,29 @@
+import { Injectable } from 'angular2/core';
+
+import { ApiService } from './api';
+import { Capture }    from '../classes/capture';
+
+@Injectable()
+export class CaptureService {
+
+  private _api: ApiService;
+
+  constructor (_api: ApiService) {
+    this._api = _api;
+  }
+
+  public list (params): Promise<Capture[]> {
+    return this._api.get('/captures', params)
+    .then((captures: Array<Object>) => captures.map((c) => new Capture(c)));
+  }
+
+  public create (payload): Promise<Capture> {
+    return this._api.post('/captures', payload)
+    .then((capture) => new Capture(capture));
+  }
+
+  public delete (payload): Promise<Object> {
+    return this._api.delete('/captures', payload);
+  }
+
+}

--- a/app/views/box.html
+++ b/app/views/box.html
@@ -1,5 +1,5 @@
-<h1>{{pokemon[0].national_id | NumberPipe : 3}} - {{pokemon[pokemon.length - 1].national_id | NumberPipe : 3}}</h1>
+<h1>{{captures[0].pokemon.national_id | NumberPipe : 3}} - {{captures[captures.length - 1].pokemon.national_id | NumberPipe : 3}}</h1>
 <div class="box-container">
-  <pokemon *ngFor="#p of pokemon" (pokemonHover)="pokemonHover.emit($event)" [pokemon]="p"></pokemon>
-  <pokemon *ngFor="#p of empties" [pokemon]="p" class="empty"></pokemon>
+  <pokemon *ngFor="#capture of captures" (pokemonHover)="pokemonHover.emit($event)" [class.captured]="capture.captured" [capture]="capture"></pokemon>
+  <pokemon *ngFor="#capture of empties" [capture]="capture" class="empty"></pokemon>
 </div>

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,2 +1,2 @@
-<header [user]="user"></header>
-<box *ngFor="#p of pokemon | GroupPipe : 30" (pokemonHover)="pokemonHover.emit($event)" [pokemon]="p"></box>
+<header [captures]="captures" [user]="user"></header>
+<box *ngFor="#group of captures | GroupPipe : 30" (pokemonHover)="pokemonHover.emit($event)" [captures]="group"></box>

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -14,17 +14,17 @@
 <div class="percentage">
   <div class="progress-container">
     <div class="progress-outer">
-      <div class="progress-inner" style="width: 40%"></div>
+      <div class="progress-inner" [style.width.%]="caught * 100 / captures.length"></div>
     </div>
-    <h3>288 caught, 433 to go!</h3>
+    <h3>{{caught}} caught, {{captures.length - caught}} to go!</h3>
   </div>
 
   <div class="region-filter-mobile">
-    <div class="active" (click)="toggleDropdown = !toggleDropdown">
+    <div class="active" (click)="dropdown = !dropdown">
       <span>National</span>
       <i class="fa fa-sort-desc"></i>
     </div>
-    <div class="dropdown" *ngIf="toggleDropdown">
+    <div class="dropdown" *ngIf="dropdown">
       <div>Kanto</div>
       <div>Johto</div>
       <div>Hoenn</div>

--- a/app/views/info.html
+++ b/app/views/info.html
@@ -1,30 +1,30 @@
-<div *ngIf="pokemon" class="info-header">
-  <img [src]="pokemon.icon_url">
-  <h1>{{pokemon.name}}</h1>
-  <h2>#{{pokemon.national_id | NumberPipe : 3}}</h2>
+<div *ngIf="capture" class="info-header">
+  <img [src]="capture.pokemon.icon_url">
+  <h1>{{capture.pokemon.name}}</h1>
+  <h2>#{{capture.pokemon.national_id | NumberPipe : 3}}</h2>
 </div>
 
-<div *ngIf="pokemon" class="info-main">
+<div *ngIf="capture" class="info-main">
   <div class="info-body">
     <h3>Pokémon Omega Ruby</h3>
     <ul>
-      <li *ngFor="#loc of pokemon.or_locations">{{loc}}</li>
+      <li *ngFor="#loc of capture.pokemon.or_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon Alpha Sapphire</h3>
     <ul>
-      <li *ngFor="#loc of pokemon.as_locations">{{loc}}</li>
+      <li *ngFor="#loc of capture.pokemon.as_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon X</h3>
     <ul>
-      <li *ngFor="#loc of pokemon.x_locations">{{loc}}</li>
+      <li *ngFor="#loc of capture.pokemon.x_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon Y</h3>
     <ul>
-      <li *ngFor="#loc of pokemon.y_locations">{{loc}}</li>
+      <li *ngFor="#loc of capture.pokemon.y_locations">{{loc}}</li>
     </ul>
   </div>
 
-  <a class="info-footer" [href]="pokemon.bulbapedia_url" target="_blank">
+  <a class="info-footer" [href]="capture.pokemon.bulbapedia_url" target="_blank">
     <div>View on Bulbapedia <i class="fa fa-long-arrow-right"></i></div>
     <i class="fa fa-external-link"></i>
   </a>

--- a/app/views/pokemon.html
+++ b/app/views/pokemon.html
@@ -1,13 +1,13 @@
-<div *ngIf="pokemon" class="pokemon-info">
-  <img [src]="pokemon.icon_url">
-  <h4>{{pokemon.name}}</h4>
-  <p>#{{pokemon.national_id | NumberPipe : 3}}</p>
+<div *ngIf="capture" class="pokemon-info">
+  <img [src]="capture.pokemon.icon_url">
+  <h4>{{capture.pokemon.name}}</h4>
+  <p>#{{capture.pokemon.national_id | NumberPipe : 3}}</p>
 </div>
 
-<div *ngIf="pokemon" class="pokemon-toggle" (mouseover)="pokemonHover.emit(pokemon)">
-  <h4>{{pokemon.name}}</h4>
-  <img [src]="pokemon.icon_url">
-  <p>#{{pokemon.national_id | NumberPipe : 3}}</p>
+<div *ngIf="capture" class="pokemon-toggle" (click)="toggle()" (mouseover)="pokemonHover.emit(capture)">
+  <h4>{{capture.pokemon.name}}</h4>
+  <img [src]="capture.pokemon.icon_url">
+  <p>#{{capture.pokemon.national_id | NumberPipe : 3}}</p>
 
   <i class="fa fa-check"></i>
 </div>

--- a/app/views/tracker.html
+++ b/app/views/tracker.html
@@ -1,5 +1,5 @@
 <nav [user]="_session.user"></nav>
 <div class="tracker">
-  <dex *ngIf="user" (pokemonHover)="active = $event" [pokemon]="pokemon" [user]="user"></dex>
-  <info [pokemon]="active"></info>
+  <dex *ngIf="!loading" (pokemonHover)="active = $event" [captures]="captures" [user]="user"></dex>
+  <info [capture]="active"></info>
 </div>


### PR DESCRIPTION
(๑ॢ˃̶͈̀ ꇴ ˂̶͈́๑ॢ)

### notes

- i think we need some sort of "pokemon loading" state when the request to toggle captured state is going through. cause if you click it twice fast, it'll send two `captured = true` requests and even though nothing bad happens (since the second one just fails), ideally, it doesn't make the request.
- also something that happens when you click fast, it sometimes selects the icon/name/number, so maybe disable selection for the pokemon box? idk if people want to be able to copy and paste the pokemon names though...
- for when you aren't logged in (or you're viewing someone else's dex), ive disabled the ability to toggle captures, but the `cursor: pointer` style is still on it, so we should have a way that turns it back to `default`.
- in the same vein, for the empty pokemon blocks in the last box (721-750), it also has `cursor: pointer` so `empty` class should be `default` as well
- the on-hover-the-info-panel-changes flow might be a little sluggish. i decided to not worry about that for now considering the fact that we're gonna be removing the hover event anyway. just keep that in mind.
- right now, it still takes a decent amount of time to load the page but i _think_ it's because the bundle.js (that's generated on the fly and is a whopping **14.3MB**) is slow. that'll be fixed once it's deployed and the bundle has been minified/uglified/gzipped, just like what we do in dashboard.
- the `/captures` endpoint is still a tad slow for my taste, but im thinking of ways to make it faster. one major limiting factor is the fact that we're "generating" fake captures if they don't exist in the DB. that iteration (check if a capture exists, if not make one) is considerably slower than a regular DB fetch (~120ms vs ~5ms), so that'd be the place to improve. idk, we'll see.

fixes #25 