### PR TITLE
feat(deploy): add prod configs to deploy

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -4,11 +4,16 @@ import 'rxjs';
 import './styles';
 
 import { bootstrap }        from 'angular2/bootstrap';
+import { enableProdMode }   from 'angular2/core';
 import { HTTP_PROVIDERS }   from 'angular2/http';
 import { ROUTER_PROVIDERS } from 'angular2/router';
 
 import { ApiService }   from './services/api';
 import { AppComponent } from './components/app';
+
+if (process.env.NODE_ENV === 'production') {
+  enableProdMode();
+}
 
 bootstrap(AppComponent, [
   ApiService,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "deploy": "ssh ubuntu@pokedextracker.com ./deployments/pokedextracker.com.sh",
     "postinstall": "typings install",
     "lint": "tslint app/*.ts app/**/*.ts",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",

--- a/typings.json
+++ b/typings.json
@@ -2,6 +2,6 @@
   "ambientDependencies": {
     "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
     "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dd638012d63e069f2c99d06ef4dcc9616a943ee4",
-    "require": "github:DefinitelyTyped/DefinitelyTyped/requirejs/require.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c"
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#315f5612ceb4de6f1f81f8cf49878084ea3f364a"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,15 @@
 'use strict';
 
-var Webpack = require('webpack');
+const Webpack = require('webpack');
+
+const PRODUCTION = process.env.NODE_ENV === 'production';
+
+const PLUGINS = [new Webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development') })];
+
+if (PRODUCTION) {
+  PLUGINS.push(new Webpack.optimize.DedupePlugin());
+  PLUGINS.push(new Webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }, mangle: false }));
+}
 
 module.exports = {
   context: __dirname + '/app',
@@ -12,7 +21,7 @@ module.exports = {
   resolve: {
     extensions: ['', '.webpack.js', '.web.js', '.ts', '.js']
   },
-  devtool: 'inline-source-map',
+  devtool: PRODUCTION ? undefined : 'inline-source-map',
   devServer: {
     contentBase: 'public/',
     historyApiFallback: true
@@ -28,5 +37,6 @@ module.exports = {
       exclude: /(test|node_modules)\//,
       loader: 'istanbul-instrumenter'
     }]
-  }
+  },
+  plugins: PLUGINS
 };


### PR DESCRIPTION
＼＼\\୧( ⁼̴̶̤̀ω⁼̴̶̤́ )૭ //／／

### notes
- to test, i deployed this branch to the server and so now it's visible at https://pokedextracker.com. things are pretty darn snappy once deployed, so that's nice :+1: 
- since some things changed in `typings.json`, you'll have to re-`npm i` (but you don't have to `rm -rf node_modules`) once this is merged

fixes #35 