### PR TITLE
feat(info): collapsible info panel

### DIFF
--- a/app/components/box.ts
+++ b/app/components/box.ts
@@ -8,7 +8,7 @@ const HTML = require('../views/box.html');
 
 @Component({
   directives: [PokemonComponent],
-  events: ['activeChange'],
+  events: ['activeChange', 'collapsedChange'],
   inputs: ['captures', 'region'],
   pipes: [NumberPipe],
   selector: 'box',
@@ -20,6 +20,7 @@ export class BoxComponent {
   public region: string;
 
   public activeChange = new EventEmitter<Capture>();
+  public collapsedChange = new EventEmitter<boolean>();
 
   private boxSize = 30;
 

--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -10,7 +10,7 @@ const HTML = require('../views/dex.html');
 
 @Component({
   directives: [HeaderComponent, BoxComponent],
-  events: ['activeChange'],
+  events: ['activeChange', 'collapsedChange'],
   inputs: ['captures', 'user'],
   pipes: [GroupPipe],
   selector: 'dex',
@@ -23,5 +23,6 @@ export class DexComponent {
   public user: User;
 
   public activeChange = new EventEmitter<Capture>();
+  public collapsedChange = new EventEmitter<boolean>();
 
 }

--- a/app/components/info.ts
+++ b/app/components/info.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component, EventEmitter } from 'angular2/core';
 
 import { Capture }    from '../classes/capture';
 import { NumberPipe } from '../pipes/number';
@@ -6,7 +6,8 @@ import { NumberPipe } from '../pipes/number';
 const HTML = require('../views/info.html');
 
 @Component({
-  inputs: ['active'],
+  events: ['collapsedChange'],
+  inputs: ['active', 'collapsed'],
   pipes: [NumberPipe],
   selector: 'info',
   template: HTML
@@ -14,5 +15,7 @@ const HTML = require('../views/info.html');
 export class InfoComponent {
 
   public active: Capture;
+
+  public collapsedChange = new EventEmitter<boolean>();
 
 }

--- a/app/components/pokemon.ts
+++ b/app/components/pokemon.ts
@@ -8,7 +8,7 @@ import { SessionService } from '../services/session';
 const HTML = require('../views/pokemon.html');
 
 @Component({
-  events: ['activeChange'],
+  events: ['activeChange', 'collapsedChange'],
   inputs: ['capture', 'region'],
   pipes: [NumberPipe],
   selector: 'pokemon',
@@ -20,6 +20,7 @@ export class PokemonComponent {
   public region: string;
 
   public activeChange = new EventEmitter<Capture>();
+  public collapsedChange = new EventEmitter<boolean>();
 
   private _capture: CaptureService;
   private _session: SessionService;

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -25,6 +25,7 @@ export class TrackerComponent implements OnInit {
   public active: Capture;
   public captures: Capture[] = [];
   public loading: boolean = true;
+  public collapsed: boolean = false;
   public _session: SessionService;
   public user: User;
 

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -14,6 +14,8 @@ import { UserService }       from '../services/user';
 
 const HTML = require('../views/tracker.html');
 
+const MOBILE_WIDTH = 1100;
+
 @Component({
   directives: [DexComponent, InfoComponent, NavComponent, NotFoundComponent],
   providers: [CaptureService, SessionService, Title, UserService],
@@ -43,6 +45,10 @@ export class TrackerComponent implements OnInit {
   }
 
   public ngOnInit () {
+    if (window.innerWidth <= MOBILE_WIDTH) {
+      this.collapsed = true;
+    }
+
     this._user.retrieve(this._routeParams.get('username'))
     .then((user) => {
       this._title.setTitle(`${this._routeParams.get('username')}'s Pokédex Tracker`);

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -7,6 +7,8 @@ tracker {
   @include flexbox();
   @include flex-grow(1);
 
+  position: relative;
+  
   .fa-venus,
   .fa-mars {
     position: relative;
@@ -18,10 +20,39 @@ tracker {
 
 info {
   @include flexbox();
-  @include flex-direction(column);
 
+  position: relative;
   background-color: $brand-secondary;
-  width: 350px;
+
+  &.collapsed .info-main {
+    display: none;
+  }
+
+  .info-collapse {
+    @include flexbox();
+    @include align-items(center);
+
+    position: absolute;
+    height: 100%;
+    padding: 8px;
+    left: -20px;
+    background-color: darken($brand-secondary-dark, 3%);
+    color: white;
+    font-size: 12px;
+
+    &:hover {
+      cursor: pointer;
+      padding-right: 10px;
+      left: -22px;
+    }
+  }
+
+  .info-main {
+    @include flexbox();
+    @include flex-direction(column);
+
+    width: 350px;
+  }
 
   .info-header {
     @include flexbox();
@@ -50,12 +81,6 @@ info {
       font-size: 17px;
       font-weight: 400;
     }
-  }
-
-  .info-main {
-    @include flexbox();
-    @include flex-direction(column);
-    @include flex-grow(1);
   }
 
   .info-body {
@@ -401,60 +426,18 @@ box {
   }
 }
 
-@media (max-width: 1020px) {
-  .tracker {
-    @include flex-direction(column);
-  }
-
+@media (max-width: 1100px) {
   info {
-    width: 100%;
-    min-height: 235px;
-
-    .info-header {
-      max-height: 50px;
-      min-height: 50px;
-      padding: 10px 10px 10px 3px;
-
-      h1 {
-        font-size: 21px;
-        font-weight: 400;
-      }
-    }
-
-    .info-main {
-      @include flex-direction(row);
-    }
-
-    .info-body {
-      padding: 20px;
-
-      h3 {
-        font-size: 9px;
-      }
-
-      ul {
-        font-size: 14px;
-        margin: 8px 0 16px;
-      }
-    }
-
-    .info-footer {
-      padding: 88px 10px;
-
-      .fa-external-link {
-        display: block;
-      }
-
-      div {
-        display: none;
-      }
-    }
+    position: absolute;
+    left: auto;
+    right: 0;
+    height: 100%;
   }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 750px) {
   dex {
-    padding: 20px;
+    padding: 20px 40px 20px 20px;
   }
 
   header,
@@ -526,6 +509,30 @@ box {
       &.empty {
         display: none;
       }
+    }
+  }
+}
+
+@media (max-width: 400px) {
+  info {
+    width: 100%;
+
+    .info-collapse {
+      position: relative;
+      left: 0;
+
+      &:hover {
+        left: 0;
+        padding-right: 8px;
+      }
+    }
+
+    .info-main {
+      width: 100%;
+    }
+
+    &.collapsed {
+      width: inherit;
     }
   }
 }

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -8,7 +8,7 @@ tracker {
   @include flex-grow(1);
 
   position: relative;
-  
+
   .fa-venus,
   .fa-mars {
     position: relative;
@@ -340,6 +340,17 @@ box {
 
       .set-info {
         opacity: 1;
+
+        &:hover {
+          right: -1px;
+          bottom: -1px;
+
+          .fa-info {
+            padding: 5px 8px;
+            border-color: darken($brand-secondary-dark, 5%);
+            color: darken($brand-secondary-dark, 5%);
+          }
+        }
       }
     }
   }
@@ -411,17 +422,6 @@ box {
       border: 2px solid $brand-secondary-light;
       color: $brand-secondary-light;
       font-size: 10px;
-    }
-
-    &:hover {
-      right: -1px;
-      bottom: -1px;
-
-      .fa-info {
-        padding: 5px 8px;
-        border-color: darken($brand-secondary-dark, 5%);
-        color: darken($brand-secondary-dark, 5%);
-      }
     }
   }
 }
@@ -501,8 +501,8 @@ box {
         width: 60px;
 
         &:hover {
-          right: 0;
-          bottom: 0;
+          right: 0 !important;
+          bottom: 0 !important;
         }
       }
 

--- a/app/views/box.html
+++ b/app/views/box.html
@@ -1,5 +1,5 @@
 <h1>{{captures[0].pokemon.national_id | NumberPipe : 3}} - {{captures[captures.length - 1].pokemon.national_id | NumberPipe : 3}}</h1>
 <div class="box-container">
-  <pokemon *ngFor="#capture of captures" (activeChange)="capture.pokemon.is(region) && activeChange.emit($event)" [class.captured]="capture.captured" [class.disabled]="!capture.pokemon.is(region)" [capture]="capture" [region]="region"></pokemon>
+  <pokemon *ngFor="#capture of captures" (activeChange)="capture.pokemon.is(region) && activeChange.emit($event)" (collapsedChange)="capture.pokemon.is(region) && collapsedChange.emit($event)" [class.captured]="capture.captured" [class.disabled]="!capture.pokemon.is(region)" [capture]="capture" [region]="region"></pokemon>
   <pokemon *ngFor="#capture of empties" [capture]="capture" class="empty"></pokemon>
 </div>

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,2 +1,2 @@
 <header [captures]="captures" [(region)]="region" [user]="user"></header>
-<box *ngFor="#group of captures | GroupPipe : 30" (activeChange)="activeChange.emit($event)" [region]="region" [captures]="group"></box>
+<box *ngFor="#group of captures | GroupPipe : 30" (activeChange)="activeChange.emit($event)" (collapsedChange)="collapsedChange.emit($event)" [region]="region" [captures]="group"></box>

--- a/app/views/info.html
+++ b/app/views/info.html
@@ -1,10 +1,14 @@
-<div *ngIf="active" class="info-header">
-  <img [src]="active.pokemon.icon_url">
-  <h1 [innerHTML]="active.pokemon.name"></h1>
-  <h2>#{{active.pokemon.national_id | NumberPipe : 3}}</h2>
+<div *ngIf="active" class="info-collapse" (click)="collapsedChange.emit(!collapsed)">
+  <i class="fa" [class.fa-caret-right]="!collapsed" [class.fa-caret-left]="collapsed"></i>
 </div>
 
 <div *ngIf="active" class="info-main">
+  <div class="info-header">
+    <img [src]="active.pokemon.icon_url">
+    <h1 [innerHTML]="active.pokemon.name"></h1>
+    <h2>#{{active.pokemon.national_id | NumberPipe : 3}}</h2>
+  </div>
+
   <div class="info-body">
     <h3>Pokémon Omega Ruby</h3>
     <ul>

--- a/app/views/pokemon.html
+++ b/app/views/pokemon.html
@@ -8,6 +8,6 @@
   <h4 *ngIf="capture">{{capture.pokemon.name}}</h4>
   <p *ngIf="capture">#{{capture.pokemon.national_id | NumberPipe : 3}}</p>
 </div>
-<div *ngIf="capture" class="set-info" (click)="activeChange.emit(capture)">
+<div *ngIf="capture" class="set-info" (click)="activeChange.emit(capture); collapsedChange.emit(false)">
   <i class="fa fa-info"></i>
 </div>

--- a/app/views/tracker.html
+++ b/app/views/tracker.html
@@ -1,6 +1,6 @@
 <nav *ngIf="!loading && user" [user]="_session.user"></nav>
 <div *ngIf="!loading && user" class="tracker">
   <dex *ngIf="!loading" (activeChange)="active = $event" [captures]="captures" [user]="user"></dex>
-  <info [active]="active"></info>
+  <info [(collapsed)]="collapsed" [class.collapsed]="collapsed" [active]="active"></info>
 </div>
 <not-found *ngIf="!loading && !user"></not-found>

--- a/app/views/tracker.html
+++ b/app/views/tracker.html
@@ -1,6 +1,6 @@
 <nav *ngIf="!loading && user" [user]="_session.user"></nav>
 <div *ngIf="!loading && user" class="tracker">
-  <dex *ngIf="!loading" (activeChange)="active = $event" [captures]="captures" [user]="user"></dex>
+  <dex *ngIf="!loading" (activeChange)="active = $event" (collapsedChange)="collapsed = $event" [captures]="captures" [user]="user"></dex>
   <info [(collapsed)]="collapsed" [class.collapsed]="collapsed" [active]="active"></info>
 </div>
 <not-found *ngIf="!loading && !user"></not-found>


### PR DESCRIPTION
꒳ᵃ꒳ᵃ꒳ᵃ~(๑°ᗨૢ°๑)♡ӵᵉ੨ᑋ✧

fixes https://github.com/robinjoseph08/pokedextracker.com/issues/17

#### what
- adds collapsible info panel
- uses that collapse functionality for a better responsive/mobile experience

#### notes
still needs:
- [x] detect browser width on load, and collapse info panel if width < 1100px (but not if someone resizes their window to below the threshold, in that case i think it should stay open)
- [x] if the panel is collapsed, when someone clicks the info button on a pokemon, it should open