### PR TITLE
fix(font): fix m/f sign for set-captured-mobile

### DIFF
--- a/app/views/pokemon.html
+++ b/app/views/pokemon.html
@@ -5,7 +5,7 @@
 </div>
 <div class="set-captured-mobile" (click)="toggle()">
   <img *ngIf="capture" [src]="capture.pokemon.icon_url">
-  <h4 *ngIf="capture">{{capture.pokemon.name}}</h4>
+  <h4 *ngIf="capture" [innerHTML]="capture.pokemon.name"></h4>
   <p *ngIf="capture">#{{capture.pokemon.national_id | NumberPipe : 3}}</p>
 </div>
 <div *ngIf="capture" class="set-info" (click)="activeChange.emit(capture); collapsedChange.emit(false)">


### PR DESCRIPTION
へ‿(ツ)‿ㄏ

fixes https://github.com/robinjoseph08/pokedextracker.com/issues/80

you must have been working on this at the same time that i was doing the responsiveness changes where i had to make duplicates of `set-caputred`, so i probably left this out in a rebase.