### PR TITLE
feat(tracker): close things when clicking outside

### DIFF
--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -1,13 +1,15 @@
 import { Component, EventEmitter } from 'angular2/core';
 import { PercentPipe }             from 'angular2/common';
 
-import { Capture }        from '../classes/capture';
-import { SessionService } from '../services/session';
-import { User }           from '../classes/user';
+import { Capture }           from '../classes/capture';
+import { OffClickDirective } from '../directives/off-click';
+import { SessionService }    from '../services/session';
+import { User }              from '../classes/user';
 
 const HTML = require('../views/header.html');
 
 @Component({
+  directives: [OffClickDirective],
   events: ['regionChange'],
   inputs: ['captures', 'region', 'user'],
   pipes: [PercentPipe],
@@ -22,12 +24,16 @@ export class HeaderComponent {
   public region: string;
   public regions: string[] = ['national', 'kanto', 'johto', 'hoenn', 'sinnoh', 'unova', 'kalos'];
   public _session: SessionService;
+  public showLink: boolean = false;
   public user: User;
 
   public regionChange = new EventEmitter<string>();
 
   constructor (_session: SessionService) {
     this._session = _session;
+
+    this.closeRegion = this.closeRegion.bind(this);
+    this.closeShare = this.closeShare.bind(this);
   }
 
   public get caught () {
@@ -36,6 +42,14 @@ export class HeaderComponent {
 
   public get total () {
     return this.captures.filter((capture) => capture.pokemon.is(this.region)).length;
+  }
+
+  public closeRegion () {
+    this.dropdown = false;
+  }
+
+  public closeShare () {
+    this.showLink = false;
   }
 
 }

--- a/app/directives/off-click.ts
+++ b/app/directives/off-click.ts
@@ -1,0 +1,24 @@
+import { Directive, OnDestroy, OnInit } from 'angular2/core';
+
+@Directive({
+  host: { '(click)': 'onClick($event)' },
+  inputs: ['offClick'],
+  selector: '[offClick]'
+})
+export class OffClickDirective implements OnInit, OnDestroy {
+
+  private offClick;
+
+  public ngOnInit () {
+    setTimeout(() => document.addEventListener('click', this.offClick), 0);
+  }
+
+  public ngOnDestroy () {
+    document.addEventListener('click', this.offClick);
+  }
+
+  public onClick ($event) {
+    $event.stopPropagation();
+  }
+
+}

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -1,5 +1,5 @@
 <h1><span *ngIf="_session.user?.id !== user.id">Viewing </span>{{user.username}}'s Living Dex</h1>
-<div class="share-container">
+<div class="share-container" [offClick]="closeShare">
   <a (click)="showLink = !showLink"><i class="fa fa-link"></i></a>
   <div class="share" *ngIf="showLink">
     Share this Living Dex:
@@ -23,7 +23,7 @@
   </div>
 
   <div class="region-filter-mobile">
-    <div class="active" (click)="dropdown = !dropdown">
+    <div class="active" (click)="dropdown = !dropdown" [offClick]="closeRegion">
       <span>{{region}}</span>
       <i class="fa fa-sort-desc"></i>
     </div>


### PR DESCRIPTION
ꉂ ૮( ᵒ̌ૢꇴᵒ̌ૢ )ა｡*ﾟ✧

fixes #104 

it works perfectly on desktop, but on mobile, for the "clicking out" to work, you need to click on "something". essentially, it works if you change the focus e.g. i have the region dropdown open and then i mark bulbasaur as captured. thats at least a step up from what it is currently (it stays open forever unless you explicitly close it).