### PR TITLE
feat(analytics): track all the things!

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -7,6 +7,7 @@ import { bootstrap }        from 'angular2/bootstrap';
 import { enableProdMode }   from 'angular2/core';
 import { HTTP_PROVIDERS }   from 'angular2/http';
 import { ROUTER_PROVIDERS } from 'angular2/router';
+import { Angulartics2 }     from 'angulartics2';
 
 import { ApiService }   from './services/api';
 import { AppComponent } from './components/app';
@@ -16,6 +17,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 bootstrap(AppComponent, [
+  Angulartics2,
   ApiService,
   HTTP_PROVIDERS,
   ROUTER_PROVIDERS

--- a/app/classes/pokemon.ts
+++ b/app/classes/pokemon.ts
@@ -4,6 +4,7 @@ export class Pokemon {
 
   public national_id: number;
   public name: string;
+  public html_name: string;
   public kanto_id: number;
   public johto_id: number;
   public hoenn_id: number;
@@ -23,7 +24,8 @@ export class Pokemon {
 
   constructor (params) {
     this.national_id = params.national_id;
-    this.name = params.name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>');
+    this.name = params.name;
+    this.html_name = params.name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>');
     this.kanto_id = params.kanto_id;
     this.johto_id = params.johto_id;
     this.hoenn_id = params.hoenn_id;

--- a/app/components/app.ts
+++ b/app/components/app.ts
@@ -1,5 +1,7 @@
-import { Component }                 from 'angular2/core';
-import { RouteConfig, RouterOutlet } from 'angular2/router';
+import { Component }                   from 'angular2/core';
+import { RouteConfig, RouterOutlet }   from 'angular2/router';
+import { Angulartics2 }                from 'angulartics2';
+import { Angulartics2GoogleAnalytics } from 'angulartics2/src/providers/angulartics2-google-analytics';
 
 import { HomeComponent }     from './home';
 import { LoginComponent }    from './login';
@@ -9,6 +11,7 @@ import { NotFoundComponent } from './not-found';
 
 @Component({
   directives: [RouterOutlet],
+  providers: [Angulartics2GoogleAnalytics],
   selector: 'app',
   template: '<router-outlet></router-outlet>'
 })
@@ -19,4 +22,14 @@ import { NotFoundComponent } from './not-found';
   { component: TrackerComponent,  name: 'Tracker',  path: '/u/:username' },
   { component: NotFoundComponent, name: 'NotFound', path: '/**' }
 ])
-export class AppComponent {}
+export class AppComponent {
+
+  private _angulartics: Angulartics2;
+  private _ga: Angulartics2GoogleAnalytics;
+
+  constructor(_angulartics: Angulartics2, _ga: Angulartics2GoogleAnalytics) {
+    this._angulartics = _angulartics;
+    this._ga = _ga;
+  }
+
+}

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter } from 'angular2/core';
 import { PercentPipe }             from 'angular2/common';
+import { Angulartics2On }          from 'angulartics2';
 
+import { CapitalizePipe }    from '../pipes/capitalize';
 import { Capture }           from '../classes/capture';
 import { OffClickDirective } from '../directives/off-click';
 import { SessionService }    from '../services/session';
@@ -9,10 +11,10 @@ import { User }              from '../classes/user';
 const HTML = require('../views/header.html');
 
 @Component({
-  directives: [OffClickDirective],
+  directives: [Angulartics2On, OffClickDirective],
   events: ['regionChange'],
   inputs: ['captures', 'region', 'user'],
-  pipes: [PercentPipe],
+  pipes: [CapitalizePipe, PercentPipe],
   providers: [SessionService],
   selector: 'header',
   template: HTML

--- a/app/components/info.ts
+++ b/app/components/info.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter } from 'angular2/core';
 import { DecimalPipe }             from 'angular2/common';
+import { Angulartics2On }          from 'angulartics2';
 
 import { Capture }                  from '../classes/capture';
 import { EvolutionFamilyComponent } from './evolution-family';
@@ -7,7 +8,7 @@ import { EvolutionFamilyComponent } from './evolution-family';
 const HTML = require('../views/info.html');
 
 @Component({
-  directives: [EvolutionFamilyComponent],
+  directives: [Angulartics2On, EvolutionFamilyComponent],
   events: ['collapsedChange'],
   inputs: ['active', 'collapsed'],
   pipes: [DecimalPipe],

--- a/app/components/login.ts
+++ b/app/components/login.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit }  from 'angular2/core';
 import { Router, RouterLink } from 'angular2/router';
 import { Title }              from 'angular2/platform/browser';
+import { Angulartics2 }       from 'angulartics2';
 
 import { NavComponent }   from './nav';
 import { SessionService } from '../services/session';
@@ -20,10 +21,12 @@ export class LoginComponent implements OnInit {
   public _session: SessionService;
   public user: User = new User({});
 
+  private _angulartics: Angulartics2;
   private _router: Router;
   private _title: Title;
 
-  constructor (_router: Router, _session: SessionService, _title: Title) {
+  constructor (_angulartics: Angulartics2, _router: Router, _session: SessionService, _title: Title) {
+    this._angulartics = _angulartics;
     this._router = _router;
     this._session = _session;
     this._title = _title;
@@ -41,7 +44,14 @@ export class LoginComponent implements OnInit {
     this.error = null;
 
     this._session.create(payload)
-    .then((session) => localStorage.setItem('token', session.token))
+    .then((session) => {
+      localStorage.setItem('token', session.token);
+
+      this._angulartics.eventTrack.next({
+        action: 'login',
+        properties: { category: 'Session' }
+      });
+    })
     .then(() => this._router.navigate(['Tracker', { username: this._session.user.username }]))
     .catch((err) => this.error = err.message);
   }

--- a/app/components/nav.ts
+++ b/app/components/nav.ts
@@ -1,5 +1,6 @@
-import { Component }  from 'angular2/core';
-import { RouterLink } from 'angular2/router';
+import { Component }    from 'angular2/core';
+import { RouterLink }   from 'angular2/router';
+import { Angulartics2 } from 'angulartics2';
 
 import { SessionService } from '../services/session';
 import { User }           from '../classes/user';
@@ -18,12 +19,20 @@ export class NavComponent {
   public _session: SessionService;
   public user: User;
 
-  constructor (_session: SessionService) {
+  private _angulartics: Angulartics2;
+
+  constructor (_angulartics: Angulartics2, _session: SessionService) {
+    this._angulartics = _angulartics;
     this._session = _session;
   }
 
   public signOut () {
     localStorage.removeItem('token');
+
+    this._angulartics.eventTrack.next({
+      action: 'sign out',
+      properties: { category: 'Session' }
+    });
   }
 
 }

--- a/app/components/register.ts
+++ b/app/components/register.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit }  from 'angular2/core';
 import { Router, RouterLink } from 'angular2/router';
 import { Title }              from 'angular2/platform/browser';
+import { Angulartics2 }       from 'angulartics2';
 
 import { NavComponent }   from './nav';
 import { SessionService } from '../services/session';
@@ -21,11 +22,13 @@ export class RegisterComponent implements OnInit {
   public _session: SessionService;
   public user: User = new User({});
 
+  private _angulartics: Angulartics2;
   private _router: Router;
   private _title: Title;
   private _user: UserService;
 
-  constructor (_router: Router, _session: SessionService, _title: Title, _user: UserService) {
+  constructor (_angulartics: Angulartics2, _router: Router, _session: SessionService, _title: Title, _user: UserService) {
+    this._angulartics = _angulartics;
     this._router = _router;
     this._session = _session;
     this._title = _title;
@@ -48,7 +51,14 @@ export class RegisterComponent implements OnInit {
     }
 
     this._user.create(payload)
-    .then((session) => localStorage.setItem('token', session.token))
+    .then((session) => {
+      localStorage.setItem('token', session.token);
+
+      this._angulartics.eventTrack.next({
+        action: 'register',
+        properties: { category: 'Session' }
+      });
+    })
     .then(() => this._router.navigate(['Tracker', { username: this._session.user.username }]))
     .catch((err) => this.error = err.message);
   }

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -1,16 +1,16 @@
 <h1><span *ngIf="_session.user?.id !== user.id">Viewing </span>{{user.username}}'s Living Dex</h1>
 <div class="share-container" [offClick]="closeShare">
-  <a (click)="showLink = !showLink"><i class="fa fa-link"></i></a>
+  <a angulartics2On="click" angularticsEvent="{{showLink ? 'open' : 'close'}}" angularticsCategory="Share" (click)="showLink = !showLink"><i class="fa fa-link"></i></a>
   <div class="share" *ngIf="showLink">
     Share this Living Dex:
-    <input #share value="https://pokedextracker.com/u/{{user.username}}" readonly (click)="share.select()">
+    <input #share value="https://pokedextracker.com/u/{{user.username}}" readonly angulartics2On="click" angularticsEvent="select link" angularticsCategory="Share" (click)="share.select()">
   </div>
 </div>
 
 <h2>FC: <span [class.fc-missing]="!user.friend_code">{{user.friend_code || 'XXXX-XXXX-XXXX'}}</span></h2>
 
 <div class="region-filter">
-  <div *ngFor="#r of regions" [class.active]="region === r" (click)="regionChange.emit(r)">{{r}}</div>
+  <div *ngFor="#r of regions" [class.active]="region === r" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r)">{{r | capitalize}}</div>
 </div>
 
 <div class="percentage">
@@ -23,12 +23,12 @@
   </div>
 
   <div class="region-filter-mobile">
-    <div class="active" (click)="dropdown = !dropdown" [offClick]="closeRegion">
-      <span>{{region}}</span>
+    <div class="active" angulartics2On="click" angularticsEvent="{{dropdown ? 'open' : 'close'}}" angularticsCategory="Region" (click)="dropdown = !dropdown" [offClick]="closeRegion">
+      <span>{{region | capitalize}}</span>
       <i class="fa fa-sort-desc"></i>
     </div>
     <div class="dropdown" *ngIf="dropdown">
-      <div *ngFor="#r of regions" [style.display]="region === r ? 'none' : 'block'" (click)="regionChange.emit(r); dropdown = false">{{r}}</div>
+      <div *ngFor="#r of regions" [style.display]="region === r ? 'none' : 'block'" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r); dropdown = false">{{r | capitalize}}</div>
     </div>
   </div>
 </div>

--- a/app/views/info.html
+++ b/app/views/info.html
@@ -1,11 +1,11 @@
-<div *ngIf="active" class="info-collapse" (click)="collapsedChange.emit(!collapsed)">
+<div *ngIf="active" class="info-collapse" angulartics2On="click" angularticsEvent="{{collapsed ? 'uncollapse' : 'collapse'}}" angularticsCategory="Info" (click)="collapsedChange.emit(!collapsed)">
   <i class="fa" [class.fa-caret-right]="!collapsed" [class.fa-caret-left]="collapsed"></i>
 </div>
 
 <div *ngIf="active" class="info-main">
   <div class="info-header">
     <img [src]="active.pokemon.icon_url">
-    <h1 [innerHTML]="active.pokemon.name"></h1>
+    <h1 [innerHTML]="active.pokemon.html_name"></h1>
     <h2>#{{active.pokemon.national_id | number : '3.0'}}</h2>
   </div>
 
@@ -30,7 +30,7 @@
 
   <evolution-family *ngIf="active.pokemon.evolution_family && !loading" class="info-evolutions" [family]="active.pokemon.evolution_family"></evolution-family>
 
-  <a class="info-footer" [href]="active.pokemon.bulbapedia_url" target="_blank">
+  <a class="info-footer" angulartics2On="click" angularticsEvent="open Bulbapedia link" angularticsCategory="Info" angularticsProperties="new Object({ label: '{{active.pokemon.name}}' })" [href]="active.pokemon.bulbapedia_url" target="_blank">
     <div>View on Bulbapedia <i class="fa fa-long-arrow-right"></i></div>
     <i class="fa fa-external-link"></i>
   </a>

--- a/app/views/pokemon.html
+++ b/app/views/pokemon.html
@@ -1,13 +1,13 @@
 <div class="set-captured" (click)="toggle()">
-  <h4 *ngIf="capture" [innerHTML]="capture.pokemon.name"></h4>
+  <h4 *ngIf="capture" [innerHTML]="capture.pokemon.html_name"></h4>
   <img *ngIf="capture" [src]="capture.pokemon.icon_url">
   <p *ngIf="capture">#{{capture.pokemon.national_id | number : '3.0'}}</p>
 </div>
 <div class="set-captured-mobile" (click)="toggle()">
   <img *ngIf="capture" [src]="capture.pokemon.icon_url">
-  <h4 *ngIf="capture" [innerHTML]="capture.pokemon.name"></h4>
+  <h4 *ngIf="capture" [innerHTML]="capture.pokemon.html_name"></h4>
   <p *ngIf="capture">#{{capture.pokemon.national_id | number : '3.0'}}</p>
 </div>
-<div *ngIf="capture" class="set-info" (click)="activeChange.emit(capture); collapsedChange.emit(false)">
+<div *ngIf="capture" class="set-info" angulartics2On="click" angularticsEvent="show info" angularticsCategory="Pokemon" angularticsProperties="new Object({ label: '{{capture.pokemon.name}}' })" (click)="activeChange.emit(capture); collapsedChange.emit(false)">
   <i class="fa fa-info"></i>
 </div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -61,6 +61,11 @@
       "from": "angular2@latest",
       "resolved": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.12.tgz"
     },
+    "angulartics2": {
+      "version": "1.0.8",
+      "from": "angulartics2@*",
+      "resolved": "https://registry.npmjs.org/angulartics2/-/angulartics2-1.0.8.tgz"
+    },
     "ansi": {
       "version": "0.3.1",
       "from": "ansi@>=0.3.1 <0.4.0",
@@ -850,7 +855,7 @@
     },
     "es6-promise": {
       "version": "3.1.2",
-      "from": "es6-promise@latest",
+      "from": "es6-promise@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
     },
     "es6-shim": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "angular2": "^2.0.0-beta.12",
+    "angulartics2": "^1.0.8",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-45307701-4', 'auto');
-      ga('send', 'pageview');
+      var _gaq = window._gaq || null;
     </script>
   </head>
   <body>


### PR DESCRIPTION
૮( ᵒ̌ૢ௰ᵒ̌ૢ )ა

im learning all sorts of things about google analytics! did you know you can track custom events? and it turns out our page tracking was wrong since it's all a single page app (russell pointed that out to me). thats why we never saw `/login` or `/register` page views, cause it wasn't correctly tracking page transitions, only the first landing.

so this pr fixes that and adds tracking for several ga events. a ga event consists of an `action`, a `category`, an optional `label`, and an optional `value`. i use the first 3, but i don't use `value` cause it has to be an integer, and i dont like that.

the events ive added tracking for:

category | action | label | notes
---|---|---|---
Session | login
Session | register
Session | sign out
Pokemon | mark | the pokemon's name
Pokemon | unmark | the pokemon's name
Pokemon | show info | the pokemon's name
Box | mark all | the number range e.g. `001 - 030`
Box | unmark all | the number range e.g. `001 - 030`
Info | open
Info | close
Region | open | | this is for mobile
Region | close* | | this is for mobile
Region | toggle | the region they toggled to
Share | open
Share | close*
Share | select link

_*this is only triggered if they close it "correctly". if they close it by clicking outside, it doesn't trigger the event._

i can show you what the events look like on the ga dashboard to you can see how these properties map to things. if you think i missed an event, lmk!