### PR TITLE
fix(styles): fix firefox bugs

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -29,6 +29,8 @@ app {
     @include flex(1 1 auto);
     @include flexbox();
     @include flex-direction(column);
+
+    min-height: 0;
   }
 }
 
@@ -136,6 +138,10 @@ input {
 
   &:focus {
     border-color: $brand-secondary-dark;
+  }
+
+  &:invalid {
+    box-shadow: none;
   }
 }
 

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -3,6 +3,7 @@
   @include flex(1 1 auto);
 
   position: relative;
+  min-height: 0;
 
   .fa-venus,
   .fa-mars {


### PR DESCRIPTION
щ(ಠ益ಠщ)

fixes https://github.com/robinjoseph08/pokedextracker.com/issues/122, if you are curious here is the reasoning: http://stackoverflow.com/questions/33790219/firefox-not-respecting-flex-shrink

ss of firefox below, verified that it still works in chrome and mobile. since my safari is still broken... can you verify that? interestingly enough, prod (pokedextracker.com) is totally fine for me in safari, it's only broken locally. CLUES!!!

![screenshot 2016-04-19 21 39 23](https://cloud.githubusercontent.com/assets/5498072/14663721/7e7fb842-0678-11e6-99c7-0234815ca750.png)