### PR TITLE
feat(dex): clickable scroll bar + back to top btn

### DIFF
--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter } from 'angular2/core';
+import { Component, ElementRef, EventEmitter } from 'angular2/core';
 
 import { BoxComponent }    from './box';
 import { Capture }         from '../classes/capture';
@@ -10,19 +10,27 @@ const HTML = require('../views/dex.html');
 
 @Component({
   directives: [HeaderComponent, BoxComponent],
-  events: ['activeChange', 'collapsedChange'],
-  inputs: ['captures', 'user'],
+  events: ['activeChange', 'collapsedChange', 'scrollUp'],
+  inputs: ['captures', 'showScroll', 'user'],
   pipes: [GroupPipe],
+  providers: [ElementRef],
   selector: 'dex',
   template: HTML
 })
 export class DexComponent {
 
   public captures: Capture[];
+  public _el: ElementRef;
   public region: string = 'national';
+  public showScroll: boolean;
   public user: User;
 
   public activeChange = new EventEmitter<Capture>();
   public collapsedChange = new EventEmitter<boolean>();
+  public scrollUp = new EventEmitter<void>();
+
+  constructor (_el: ElementRef) {
+    this._el = _el;
+  }
 
 }

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -15,7 +15,8 @@ import { UserService }       from '../services/user';
 
 const HTML = require('../views/tracker.html');
 
-const MOBILE_WIDTH = 1100;
+const MOBILE_WIDTH          = 1100;
+const SHOW_SCROLL_THRESHOLD = 400;
 
 @Component({
   directives: [DexComponent, InfoComponent, NavComponent, NotFoundComponent],
@@ -30,6 +31,7 @@ export class TrackerComponent implements OnInit {
   public loading: boolean = true;
   public collapsed: boolean = false;
   public _session: SessionService;
+  public showScroll: boolean = false;
   public user: User;
 
   private _capture: CaptureService;
@@ -64,6 +66,21 @@ export class TrackerComponent implements OnInit {
       this.loading = false;
     })
     .catch((err) => this.loading = false);
+  }
+
+  public scroll (dex: DexComponent) {
+    const el: HTMLElement = dex._el.nativeElement;
+    if (!this.showScroll && el.scrollTop >= SHOW_SCROLL_THRESHOLD) {
+      this.showScroll = true;
+    } else if (this.showScroll && el.scrollTop < SHOW_SCROLL_THRESHOLD) {
+      this.showScroll = false;
+    }
+  }
+
+  public scrollUp (dex: DexComponent) {
+    const el: HTMLElement = dex._el.nativeElement;
+    el.scrollTop = 0;
+    this.showScroll = false;
   }
 
 }

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -18,7 +18,7 @@ info {
   @include flexbox();
 
   position: relative;
-  background-color: $brand-secondary;
+  z-index: 2;
 
   &.collapsed .info-main {
     display: none;
@@ -28,10 +28,7 @@ info {
     @include flexbox();
     @include align-items(center);
 
-    position: absolute;
-    height: 100%;
     padding: 8px;
-    left: -20px;
     background-color: darken($brand-secondary-dark, 3%);
     color: white;
     font-size: 12px;
@@ -39,7 +36,7 @@ info {
     &:hover {
       cursor: pointer;
       padding-right: 10px;
-      left: -22px;
+      margin-left: -2px;
     }
   }
 
@@ -48,6 +45,7 @@ info {
     @include flex-direction(column);
 
     width: 350px;
+    background-color: $brand-secondary;
     color: #fff;
 
     > * {
@@ -60,6 +58,7 @@ info {
     @include align-items(center);
 
     padding: 17px 17px 17px 8px;
+    background-color: $brand-secondary;
     border-bottom: 2px solid $brand-secondary-dark;
 
     img {
@@ -87,6 +86,7 @@ info {
     @include overflow-y-scroll;
 
     padding: 30px;
+    background-color: $brand-secondary;
     border-bottom: 2px solid $brand-secondary-dark;
 
     h3 {
@@ -115,6 +115,7 @@ info {
     @include justify-content(center);
 
     padding: 20px;
+    background-color: $brand-secondary;
     text-align: center;
     font-size: 13px;
 
@@ -237,6 +238,31 @@ dex {
   @include overflow-y-scroll;
 
   padding: 100px 0;
+
+  .scroll-up {
+    @include transition(all .1s ease-out);
+    @include flexbox();
+    @include align-items(center);
+    @include justify-content(center);
+
+    position: fixed;
+    left: 10px;
+    bottom: 10px;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    box-shadow: 1px 1px 3px rgba(0,0,0,0.5);
+    background-color: $brand-secondary;
+    color: #fff;
+    font-size: 11px;
+    z-index: 1;
+
+    &:hover,
+    &:focus {
+      cursor: pointer;
+      background-color: $brand-secondary-dark;
+    }
+  }
 }
 
 header {
@@ -613,16 +639,26 @@ box {
 
 @media (max-width: 1100px) {
   info {
-    position: absolute;
-    left: auto;
-    right: 0;
-    height: 100%;
+    .info-collapse {
+      position: relative;
+      right: 350px;
+    }
+
+    &.collapsed .info-collapse {
+      right: 0;
+    }
+
+    .info-main {
+      position: absolute;
+      right: 0;
+      height: 100%;
+    }
   }
 }
 
 @media (max-width: 750px) {
   dex {
-    padding: 15px 35px 15px 15px;
+    padding: 15px;
   }
 
   header,
@@ -715,20 +751,28 @@ box {
 }
 
 @media (max-width: 400px) {
+  dex {
+    padding: 15px 35px 15px 15px;
+  }
+
   info {
+    position: absolute;
+    left: auto;
+    right: 0;
+    height: 100%;
     width: 100%;
 
     .info-collapse {
-      position: relative;
-      left: 0;
+      right: 0;
 
       &:hover {
-        left: 0;
+        margin-left: 0;
         padding-right: 8px;
       }
     }
 
     .info-main {
+      position: relative;
       width: 100%;
     }
 

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -240,14 +240,15 @@ dex {
   padding: 100px 0;
 
   .scroll-up {
-    @include transition(all .1s ease-out);
+    @include transition(all .5s ease-out);
     @include flexbox();
     @include align-items(center);
     @include justify-content(center);
 
+    opacity: 0;
     position: fixed;
     left: 10px;
-    bottom: 10px;
+    bottom: -100px;
     width: 50px;
     height: 50px;
     border-radius: 50%;
@@ -261,6 +262,11 @@ dex {
     &:focus {
       cursor: pointer;
       background-color: $brand-secondary-dark;
+    }
+
+    &.visible {
+      bottom: 10px;
+      opacity: 1;
     }
   }
 }

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,3 +1,3 @@
-<div class="scroll-up"><i class="fa fa-long-arrow-up"></i></div>
+<div class="scroll-up" [class.visible]="showScroll" (click)="scrollUp.emit()"><i class="fa fa-long-arrow-up"></i></div>
 <header [captures]="captures" [(region)]="region" [user]="user"></header>
 <box *ngFor="#group of captures | group : 30" (activeChange)="activeChange.emit($event)" (collapsedChange)="collapsedChange.emit($event)" [captures]="group" [region]="region" [user]="user"></box>

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,2 +1,3 @@
+<div class="scroll-up"><i class="fa fa-long-arrow-up"></i></div>
 <header [captures]="captures" [(region)]="region" [user]="user"></header>
 <box *ngFor="#group of captures | group : 30" (activeChange)="activeChange.emit($event)" (collapsedChange)="collapsedChange.emit($event)" [captures]="group" [region]="region" [user]="user"></box>

--- a/app/views/tracker.html
+++ b/app/views/tracker.html
@@ -1,7 +1,7 @@
 <div *ngIf="loading" class="loading">Loading...</div>
 <nav *ngIf="!loading && user" [user]="user"></nav>
 <div *ngIf="!loading && user" class="tracker">
-  <dex *ngIf="!loading" (activeChange)="active = $event" (collapsedChange)="collapsed = $event" [captures]="captures" [user]="user"></dex>
+  <dex #dex (scroll)="scroll(dex)" *ngIf="!loading" (activeChange)="active = $event" (collapsedChange)="collapsed = $event" (scrollUp)="scrollUp(dex)" [captures]="captures" [showScroll]="showScroll" [user]="user"></dex>
   <info [(collapsed)]="collapsed" [class.collapsed]="collapsed" [active]="active"></info>
 </div>
 <not-found *ngIf="!loading && !user"></not-found>


### PR DESCRIPTION
ෆු(*˃ர்˂*)ෆු

fixes https://github.com/robinjoseph08/pokedextracker.com/issues/117

can you add the actual back-to-top functionality for the button? also, ideally it's not there if you're at the top and only shows up maybe 50-100px down. also it'd be cool if it animated and slid in from the bottom (bonus cookie points!!).

one caveat for the scrollbar now being within the dex area + clickable - if you're in a weird "mid" state, but the info panel is expanded, the scroll bar is on the right within the info area. it's pretty unavoidable though since, in that mode, the panel is essentially absolutely positioned. i think it's fine though, because the rest of the time the scrollbar is exposed as expected.

![screenshot 2016-04-23 21 57 35](https://cloud.githubusercontent.com/assets/5498072/14765776/05af7f3e-09a6-11e6-8a18-92f1b4a98715.png)