### PR TITLE
chore(deps): upgrade angular beta.12 -> beta.17

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import 'rxjs';
 import './styles';
 
-import { bootstrap }        from 'angular2/bootstrap';
+import { bootstrap }        from 'angular2/platform/browser';
 import { enableProdMode }   from 'angular2/core';
 import { HTTP_PROVIDERS }   from 'angular2/http';
 import { ROUTER_PROVIDERS } from 'angular2/router';

--- a/app/components/box.ts
+++ b/app/components/box.ts
@@ -63,7 +63,7 @@ export class BoxComponent {
     })
     .then(() => {
       const pipe = new DecimalPipe();
-      const args = ['3.0'];
+      const args = '3.0';
 
       this.captures.map((capture) => capture.captured = markAll);
       this._angulartics.eventTrack.next({

--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -13,7 +13,6 @@ const HTML = require('../views/dex.html');
   events: ['activeChange', 'collapsedChange', 'scrollUp'],
   inputs: ['captures', 'showScroll', 'user'],
   pipes: [GroupPipe],
-  providers: [ElementRef],
   selector: 'dex',
   template: HTML
 })

--- a/app/pipes/group.ts
+++ b/app/pipes/group.ts
@@ -3,7 +3,7 @@ import { Pipe } from 'angular2/core';
 @Pipe({ name: 'group' })
 export class GroupPipe {
 
-  public transform (arr, [size]) {
+  public transform (arr, size) {
     return arr.reduce((acc, item, i) => {
       const group = Math.ceil((i + 1) / size) - 1;
       acc[group] = acc[group] || [];

--- a/app/views/box.html
+++ b/app/views/box.html
@@ -6,6 +6,6 @@
   </button>
 </div>
 <div class="box-container">
-  <pokemon *ngFor="#capture of captures" (activeChange)="capture.pokemon.is(region) && activeChange.emit($event)" (collapsedChange)="capture.pokemon.is(region) && collapsedChange.emit($event)" [class.captured]="capture.captured" [class.disabled]="!capture.pokemon.is(region)" [class.viewing]="_session.user?.id !== user.id" [capture]="capture" [region]="region"></pokemon>
-  <pokemon *ngFor="#capture of empties" [capture]="capture" class="empty"></pokemon>
+  <pokemon *ngFor="let capture of captures" (activeChange)="capture.pokemon.is(region) && activeChange.emit($event)" (collapsedChange)="capture.pokemon.is(region) && collapsedChange.emit($event)" [class.captured]="capture.captured" [class.disabled]="!capture.pokemon.is(region)" [class.viewing]="_session.user?.id !== user.id" [capture]="capture" [region]="region"></pokemon>
+  <pokemon *ngFor="let capture of empties" [capture]="capture" class="empty"></pokemon>
 </div>

--- a/app/views/dex.html
+++ b/app/views/dex.html
@@ -1,3 +1,3 @@
 <div class="scroll-up" [class.visible]="showScroll" (click)="scrollUp.emit()"><i class="fa fa-long-arrow-up"></i></div>
 <header [captures]="captures" [(region)]="region" [user]="user"></header>
-<box *ngFor="#group of captures | group : 30" (activeChange)="activeChange.emit($event)" (collapsedChange)="collapsedChange.emit($event)" [captures]="group" [region]="region" [user]="user"></box>
+<box *ngFor="let group of captures | group : 30" (activeChange)="activeChange.emit($event)" (collapsedChange)="collapsedChange.emit($event)" [captures]="group" [region]="region" [user]="user"></box>

--- a/app/views/evolution-family.html
+++ b/app/views/evolution-family.html
@@ -4,13 +4,13 @@
 </div>
 <evolutions *ngIf="family.evolutions.length > 0" class="evolution-trigger-column" [evolutions]="family.evolutions[0]"></evolutions>
 <div *ngIf="family.pokemon.length > 1" class="evolution-pokemon-column">
-  <a *ngFor="#pokemon of family.pokemon[1]" (click)="activeChange.emit(pokemon)">
+  <a *ngFor="let pokemon of family.pokemon[1]" (click)="activeChange.emit(pokemon)">
     <img [src]="pokemon.icon_url">
   </a>
 </div>
 <evolutions *ngIf="family.evolutions.length > 1" class="evolution-trigger-column" [evolutions]="family.evolutions[1]"></evolutions>
 <div *ngIf="family.pokemon.length > 2" class="evolution-pokemon-column">
-  <a *ngFor="#pokemon of family.pokemon[2]" (click)="activeChange.emit(pokemon)">
+  <a *ngFor="let pokemon of family.pokemon[2]" (click)="activeChange.emit(pokemon)">
     <img [src]="pokemon.icon_url">
   </a>
 </div>

--- a/app/views/evolutions.html
+++ b/app/views/evolutions.html
@@ -1,4 +1,4 @@
-<div *ngFor="#evolution of evolutions" class="evolution-trigger">
+<div *ngFor="let evolution of evolutions" class="evolution-trigger">
   <i [class.fa-long-arrow-right]="evolution.trigger !== 'breed'" [class.fa-long-arrow-left]="evolution.trigger === 'breed'" class="fa"></i>
   <div>
     <span [ngSwitch]="evolution.trigger">

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -10,7 +10,7 @@
 <h2>FC: <span [class.fc-missing]="!user.friend_code">{{user.friend_code || 'XXXX-XXXX-XXXX'}}</span></h2>
 
 <div class="region-filter">
-  <div *ngFor="#r of regions" [class.active]="region === r" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r)">{{r | capitalize}}</div>
+  <div *ngFor="let r of regions" [class.active]="region === r" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r)">{{r | capitalize}}</div>
 </div>
 
 <div class="percentage">
@@ -28,7 +28,7 @@
       <i class="fa fa-sort-desc"></i>
     </div>
     <div class="dropdown" *ngIf="dropdown">
-      <div *ngFor="#r of regions" [style.display]="region === r ? 'none' : 'block'" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r); dropdown = false">{{r | capitalize}}</div>
+      <div *ngFor="let r of regions" [style.display]="region === r ? 'none' : 'block'" angulartics2On="click" angularticsEvent="toggle" angularticsCategory="Region" angularticsProperties="new Object({ label: '{{r | capitalize}}' })" (click)="regionChange.emit(r); dropdown = false">{{r | capitalize}}</div>
     </div>
   </div>
 </div>

--- a/app/views/info.html
+++ b/app/views/info.html
@@ -12,19 +12,19 @@
   <div *ngIf="!loading" class="info-locations">
     <h3>Pokémon Omega Ruby</h3>
     <ul>
-      <li *ngFor="#loc of active.or_locations">{{loc}}</li>
+      <li *ngFor="let loc of active.or_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon Alpha Sapphire</h3>
     <ul>
-      <li *ngFor="#loc of active.as_locations">{{loc}}</li>
+      <li *ngFor="let loc of active.as_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon X</h3>
     <ul>
-      <li *ngFor="#loc of active.x_locations">{{loc}}</li>
+      <li *ngFor="let loc of active.x_locations">{{loc}}</li>
     </ul>
     <h3>Pokémon Y</h3>
     <ul>
-      <li *ngFor="#loc of active.y_locations">{{loc}}</li>
+      <li *ngFor="let loc of active.y_locations">{{loc}}</li>
     </ul>
   </div>
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -57,14 +57,14 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "angular2": {
-      "version": "2.0.0-beta.12",
+      "version": "2.0.0-beta.17",
       "from": "angular2@latest",
-      "resolved": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.12.tgz"
+      "resolved": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.17.tgz"
     },
     "angulartics2": {
-      "version": "1.0.8",
-      "from": "angulartics2@*",
-      "resolved": "https://registry.npmjs.org/angulartics2/-/angulartics2-1.0.8.tgz"
+      "version": "1.0.10",
+      "from": "angulartics2@1.0.10",
+      "resolved": "https://registry.npmjs.org/angulartics2/-/angulartics2-1.0.10.tgz"
     },
     "ansi": {
       "version": "0.3.1",
@@ -3467,9 +3467,9 @@
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "rxjs": {
-      "version": "5.0.0-beta.2",
-      "from": "rxjs@>=5.0.0-beta.2 <6.0.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.2.tgz"
+      "version": "5.0.0-beta.6",
+      "from": "rxjs@5.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.6.tgz"
     },
     "sass-graph": {
       "version": "2.1.1",
@@ -4299,9 +4299,9 @@
       "resolved": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz"
     },
     "zone.js": {
-      "version": "0.6.6",
+      "version": "0.6.12",
       "from": "zone.js@latest",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.6.tgz"
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.12.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "typings": "typings"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.12",
-    "angulartics2": "^1.0.8",
+    "angular2": "^2.0.0-beta.17",
+    "angulartics2": "^1.0.10",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "^5.0.0-beta.2",
-    "zone.js": "^0.6.6"
+    "rxjs": "^5.0.0-beta.6",
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "css-loader": "^0.23.1",


### PR DESCRIPTION
(۶* ‘ꆚ’)۶”

updated to the latest beta! from here, ill update to the latest rc but thats probably a bigger change.

changes include (for documentation purposes):

- importing `bootstrap` from `angular2/platform/browser` instead of `'angular2/bootstrap` (added in beta.15)
- pipes take variable args instead of an array (added in beta.16)
- change syntax of `*ngFor` from `#item of items` to `let item of items` (added in beta.17)
- remove `providers: [ElementRef]` (don't know why, but it was apparently breaking everything, showed no errors, and took forever to debug -_-)

@ami all you need to do is checkout the branch, `npm i`, `npm start`, and see if all of the pages/functionality still works! hopefully we have more luck than in #127 