### PR TITLE
chore(deps): upgrade angular beta.17 -> rc.4

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -3,11 +3,12 @@ import 'reflect-metadata';
 import 'rxjs';
 import './styles';
 
-import { bootstrap }        from 'angular2/platform/browser';
-import { enableProdMode }   from 'angular2/core';
-import { HTTP_PROVIDERS }   from 'angular2/http';
-import { ROUTER_PROVIDERS } from 'angular2/router';
-import { Angulartics2 }     from 'angulartics2';
+import { bootstrap }                            from '@angular/platform-browser-dynamic';
+import { disableDeprecatedForms, provideForms } from '@angular/forms';
+import { enableProdMode }                       from '@angular/core';
+import { HTTP_PROVIDERS }                       from '@angular/http';
+import { ROUTER_PROVIDERS }                     from '@angular/router-deprecated';
+import { Angulartics2 }                         from 'angulartics2';
 
 import { ApiService }   from './services/api';
 import { AppComponent } from './components/app';
@@ -18,6 +19,8 @@ if (Config.ENABLE_PRODUCTION) {
 }
 
 bootstrap(AppComponent, [
+  disableDeprecatedForms(),
+  provideForms(),
   Angulartics2,
   ApiService,
   HTTP_PROVIDERS,

--- a/app/classes/capture.ts
+++ b/app/classes/capture.ts
@@ -1,3 +1,5 @@
+import { DomSanitizationService } from '@angular/platform-browser';
+
 import { Pokemon }        from './pokemon';
 import { PokemonService } from '../services/pokemon';
 
@@ -9,9 +11,9 @@ export class Capture {
 
   private _pokemon: PokemonService;
 
-  constructor (params, _pokemon: PokemonService) {
+  constructor (params, _pokemon: PokemonService, _sanitizer: DomSanitizationService) {
     this.user_id = params.user_id;
-    this.pokemon = new Pokemon(params.pokemon);
+    this.pokemon = new Pokemon(params.pokemon, _sanitizer);
     this.captured = params.captured;
 
     this._pokemon = _pokemon;

--- a/app/classes/evolution-family.ts
+++ b/app/classes/evolution-family.ts
@@ -1,3 +1,5 @@
+import { DomSanitizationService } from '@angular/platform-browser';
+
 import { Evolution } from './evolution';
 import { Pokemon }   from './pokemon';
 
@@ -6,8 +8,8 @@ export class EvolutionFamily {
   public pokemon: Pokemon[][];
   public evolutions: Evolution[][];
 
-  constructor (params) {
-    this.pokemon = params.pokemon.map((stage) => stage.map((p) => new Pokemon(p)));
+  constructor (params, _sanitizer: DomSanitizationService) {
+    this.pokemon = params.pokemon.map((stage) => stage.map((p) => new Pokemon(p, _sanitizer)));
     this.evolutions = params.evolutions.map((stage) => stage.map((e) => new Evolution(e)));
   }
 

--- a/app/classes/pokemon.ts
+++ b/app/classes/pokemon.ts
@@ -1,10 +1,12 @@
+import { DomSanitizationService, SafeHtml } from '@angular/platform-browser';
+
 import { EvolutionFamily } from './evolution-family';
 
 export class Pokemon {
 
   public national_id: number;
   public name: string;
-  public html_name: string;
+  public html_name: SafeHtml;
   public kanto_id: number;
   public johto_id: number;
   public hoenn_id: number;
@@ -23,10 +25,10 @@ export class Pokemon {
   public as_locations: string[];
   public evolution_family: EvolutionFamily;
 
-  constructor (params) {
+  constructor (params, _sanitizer: DomSanitizationService) {
     this.national_id = params.national_id;
     this.name = params.name;
-    this.html_name = params.name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>');
+    this.html_name = _sanitizer.bypassSecurityTrustHtml(params.name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>'));
     this.kanto_id = params.kanto_id;
     this.johto_id = params.johto_id;
     this.hoenn_id = params.hoenn_id;
@@ -43,7 +45,7 @@ export class Pokemon {
     this.y_locations = params.y_locations;
     this.or_locations = params.or_locations;
     this.as_locations = params.as_locations;
-    this.evolution_family = params.evolution_family && new EvolutionFamily(params.evolution_family);
+    this.evolution_family = params.evolution_family && new EvolutionFamily(params.evolution_family, _sanitizer);
   }
 
   public is (region: string): boolean {

--- a/app/components/app.ts
+++ b/app/components/app.ts
@@ -1,5 +1,5 @@
-import { Component }                   from 'angular2/core';
-import { RouteConfig, RouterOutlet }   from 'angular2/router';
+import { Component }                   from '@angular/core';
+import { RouteConfig, RouterOutlet }   from '@angular/router-deprecated';
 import { Angulartics2 }                from 'angulartics2';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/src/providers/angulartics2-google-analytics';
 

--- a/app/components/box.ts
+++ b/app/components/box.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter } from 'angular2/core';
-import { DecimalPipe }             from 'angular2/common';
+import { Component, EventEmitter } from '@angular/core';
+import { DecimalPipe }             from '@angular/common';
 import { Angulartics2 }            from 'angulartics2';
 
 import { Capture }          from '../classes/capture';

--- a/app/components/dex.ts
+++ b/app/components/dex.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter } from 'angular2/core';
+import { Component, ElementRef, EventEmitter } from '@angular/core';
 
 import { BoxComponent }    from './box';
 import { Capture }         from '../classes/capture';

--- a/app/components/evolution-family.ts
+++ b/app/components/evolution-family.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter } from 'angular2/core';
+import { Component, EventEmitter } from '@angular/core';
 
 import { EvolutionsComponent } from './evolutions';
 import { EvolutionFamily }     from '../classes/evolution-family';

--- a/app/components/evolutions.ts
+++ b/app/components/evolutions.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 
 import { CapitalizePipe } from '../pipes/capitalize';
 import { Evolution }      from '../classes/evolution';

--- a/app/components/header.ts
+++ b/app/components/header.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter } from 'angular2/core';
-import { PercentPipe }             from 'angular2/common';
+import { Component, EventEmitter } from '@angular/core';
+import { PercentPipe }             from '@angular/common';
 import { Angulartics2On }          from 'angulartics2';
 
 import { CapitalizePipe }    from '../pipes/capitalize';

--- a/app/components/home.ts
+++ b/app/components/home.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit }  from 'angular2/core';
-import { Router, RouterLink } from 'angular2/router';
-import { Title }              from 'angular2/platform/browser';
+import { Component, OnInit }  from '@angular/core';
+import { Router, RouterLink } from '@angular/router-deprecated';
+import { Title }              from '@angular/platform-browser';
 
 import { SessionService } from '../services/session';
 

--- a/app/components/info.ts
+++ b/app/components/info.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter } from 'angular2/core';
-import { DecimalPipe }             from 'angular2/common';
+import { Component, EventEmitter } from '@angular/core';
+import { DecimalPipe }             from '@angular/common';
 import { Angulartics2On }          from 'angulartics2';
 
 import { EvolutionFamilyComponent } from './evolution-family';

--- a/app/components/login.ts
+++ b/app/components/login.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit }  from 'angular2/core';
-import { Router, RouterLink } from 'angular2/router';
-import { Title }              from 'angular2/platform/browser';
+import { Component, OnInit }  from '@angular/core';
+import { Router, RouterLink } from '@angular/router-deprecated';
+import { Title }              from '@angular/platform-browser';
 import { Angulartics2 }       from 'angulartics2';
 
 import { NavComponent }   from './nav';

--- a/app/components/nav.ts
+++ b/app/components/nav.ts
@@ -1,5 +1,5 @@
-import { Component }    from 'angular2/core';
-import { RouterLink }   from 'angular2/router';
+import { Component }    from '@angular/core';
+import { RouterLink }   from '@angular/router-deprecated';
 import { Angulartics2 } from 'angulartics2';
 
 import { SessionService } from '../services/session';

--- a/app/components/not-found.ts
+++ b/app/components/not-found.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from 'angular2/core';
-import { Title }             from 'angular2/platform/browser';
+import { Component, OnInit } from '@angular/core';
+import { Title }             from '@angular/platform-browser';
 
 import { NavComponent }   from './nav';
 import { SessionService } from '../services/session';

--- a/app/components/pokemon.ts
+++ b/app/components/pokemon.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter }      from 'angular2/core';
-import { DecimalPipe }                  from 'angular2/common';
+import { Component, EventEmitter }      from '@angular/core';
+import { DecimalPipe }                  from '@angular/common';
 import { Angulartics2, Angulartics2On } from 'angulartics2';
 
 import { Capture }        from '../classes/capture';

--- a/app/components/register.ts
+++ b/app/components/register.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit }  from 'angular2/core';
-import { Router, RouterLink } from 'angular2/router';
-import { Title }              from 'angular2/platform/browser';
+import { Component, OnInit }  from '@angular/core';
+import { Router, RouterLink } from '@angular/router-deprecated';
+import { Title }              from '@angular/platform-browser';
 import { Angulartics2 }       from 'angulartics2';
 
 import { NavComponent }   from './nav';

--- a/app/components/tracker.ts
+++ b/app/components/tracker.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from 'angular2/core';
-import { RouteParams }       from 'angular2/router';
-import { Title }             from 'angular2/platform/browser';
+import { Component, OnInit } from '@angular/core';
+import { RouteParams }       from '@angular/router-deprecated';
+import { Title }             from '@angular/platform-browser';
 
 import { Capture }           from '../classes/capture';
 import { CaptureService }    from '../services/capture';

--- a/app/directives/off-click.ts
+++ b/app/directives/off-click.ts
@@ -1,4 +1,4 @@
-import { Directive, OnDestroy, OnInit } from 'angular2/core';
+import { Directive, OnDestroy, OnInit } from '@angular/core';
 
 @Directive({
   host: { '(click)': 'onClick($event)' },

--- a/app/pipes/capitalize.ts
+++ b/app/pipes/capitalize.ts
@@ -1,4 +1,4 @@
-import { Pipe } from 'angular2/core';
+import { Pipe } from '@angular/core';
 
 @Pipe({ name: 'capitalize' })
 export class CapitalizePipe {

--- a/app/pipes/group.ts
+++ b/app/pipes/group.ts
@@ -1,4 +1,4 @@
-import { Pipe } from 'angular2/core';
+import { Pipe } from '@angular/core';
 
 @Pipe({ name: 'group' })
 export class GroupPipe {

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -1,5 +1,5 @@
-import { Injectable }                                     from 'angular2/core';
-import { Headers, Http, RequestOptions, URLSearchParams } from 'angular2/http';
+import { Injectable }                                     from '@angular/core';
+import { Headers, Http, RequestOptions, URLSearchParams } from '@angular/http';
 
 import { Config } from '../../config';
 

--- a/app/services/capture.ts
+++ b/app/services/capture.ts
@@ -1,4 +1,5 @@
-import { Injectable } from 'angular2/core';
+import { DomSanitizationService } from '@angular/platform-browser';
+import { Injectable }             from '@angular/core';
 
 import { ApiService }     from './api';
 import { Capture }        from '../classes/capture';
@@ -9,20 +10,22 @@ export class CaptureService {
 
   private _api: ApiService;
   private _pokemon: PokemonService;
+  private _sanitizer: DomSanitizationService;
 
-  constructor (_api: ApiService, _pokemon: PokemonService) {
+  constructor (_api: ApiService, _pokemon: PokemonService, _sanitizer: DomSanitizationService) {
     this._api = _api;
     this._pokemon = _pokemon;
+    this._sanitizer = _sanitizer;
   }
 
   public list (params): Promise<Capture[]> {
     return this._api.get('/captures', params)
-    .then((captures: Array<Object>) => captures.map((c) => new Capture(c, this._pokemon)));
+    .then((captures: Array<Object>) => captures.map((c) => new Capture(c, this._pokemon, this._sanitizer)));
   }
 
   public create (payload): Promise<Capture[]> {
     return this._api.post('/captures', payload)
-    .then((captures: Array<Object>) => captures.map((c) => new Capture(c, this._pokemon)));
+    .then((captures: Array<Object>) => captures.map((c) => new Capture(c, this._pokemon, this._sanitizer)));
   }
 
   public delete (payload): Promise<Object> {

--- a/app/services/pokemon.ts
+++ b/app/services/pokemon.ts
@@ -1,4 +1,5 @@
-import { Injectable } from 'angular2/core';
+import { DomSanitizationService } from '@angular/platform-browser';
+import { Injectable }             from '@angular/core';
 
 import { ApiService } from './api';
 import { Pokemon }    from '../classes/pokemon';
@@ -8,14 +9,16 @@ export class PokemonService {
 
   private _api: ApiService;
   private _cache: Pokemon[] = [];
+  private _sanitizer: DomSanitizationService;
 
-  constructor (_api: ApiService) {
+  constructor (_api: ApiService, _sanitizer: DomSanitizationService) {
     this._api = _api;
+    this._sanitizer = _sanitizer;
   }
 
   public list (): Promise<Pokemon[]> {
     return this._api.get('/pokemon')
-    .then((pokemon: Array<Object>) => pokemon.map((p) => new Pokemon(p)));
+    .then((pokemon: Array<Object>) => pokemon.map((p) => new Pokemon(p, this._sanitizer)));
   }
 
   public retrieve (id: number): Promise<Pokemon> {
@@ -24,7 +27,7 @@ export class PokemonService {
     } else {
       return this._api.get(`/pokemon/${id}`)
       .then((pokemon) => {
-        this._cache[id] = new Pokemon(pokemon);
+        this._cache[id] = new Pokemon(pokemon, this._sanitizer);
         return this._cache[id];
       });
     }

--- a/app/services/session.ts
+++ b/app/services/session.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 
 import { ApiService } from './api';
 import { Session }    from '../classes/session';

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 
 import { ApiService } from './api';
 import { Session }    from '../classes/session';

--- a/app/views/evolutions.html
+++ b/app/views/evolutions.html
@@ -2,12 +2,12 @@
   <i [class.fa-long-arrow-right]="evolution.trigger !== 'breed'" [class.fa-long-arrow-left]="evolution.trigger === 'breed'" class="fa"></i>
   <div>
     <span [ngSwitch]="evolution.trigger">
-      <span *ngSwitchWhen="'level'">
+      <span *ngSwitchCase="'level'">
         Level Up <span *ngIf="evolution.level">to {{evolution.level}}</span>
       </span>
-      <span *ngSwitchWhen="'stone'">{{evolution.stone | capitalize}} Stone</span>
-      <span *ngSwitchWhen="'trade'">Trade</span>
-      <span *ngSwitchWhen="'breed'">Breed</span>
+      <span *ngSwitchCase="'stone'">{{evolution.stone | capitalize}} Stone</span>
+      <span *ngSwitchCase="'trade'">Trade</span>
+      <span *ngSwitchCase="'breed'">Breed</span>
     </span>
     <span *ngIf="evolution.held_item">holding {{evolution.held_item | capitalize}}</span>
     <span *ngIf="evolution.notes">

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -6,12 +6,12 @@
     </div>
     <div class="form-group">
       <label for="username">Username</label>
-      <input [(ngModel)]="user.username" id="username" type="text" required placeholder="ashketchum10" maxlength="20" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+      <input [(ngModel)]="user.username" name="username" id="username" type="text" required placeholder="ashketchum10" maxlength="20" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       <i class="fa fa-asterisk"></i>
     </div>
     <div class="form-group">
       <label for="password">Password</label>
-      <input [(ngModel)]="user.password" id="password" type="password" required placeholder="••••••••••••" maxlength="72">
+      <input [(ngModel)]="user.password" name="password" id="password" type="password" required placeholder="••••••••••••" maxlength="72">
       <i class="fa fa-asterisk"></i>
     </div>
     <button type="submit">Let's go! <i class="fa fa-long-arrow-right"></i></button>

--- a/app/views/register.html
+++ b/app/views/register.html
@@ -6,22 +6,22 @@
     </div>
     <div class="form-group">
       <label for="username">Username</label>
-      <input [(ngModel)]="user.username" id="username" type="text" required placeholder="ashketchum10" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+      <input [(ngModel)]="user.username" name="username" id="username" type="text" required placeholder="ashketchum10" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       <i class="fa fa-asterisk"></i>
     </div>
     <div class="form-group">
       <label for="password">Password</label>
-      <input [(ngModel)]="user.password" id="password" type="password" required placeholder="••••••••••••">
+      <input [(ngModel)]="user.password" name="password" id="password" type="password" required placeholder="••••••••••••">
       <i class="fa fa-asterisk"></i>
     </div>
     <div class="form-group">
       <label for="password_confirm">Confirm Password</label>
-      <input [(ngModel)]="user.password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••">
+      <input [(ngModel)]="user.password_confirm" name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••">
       <i class="fa fa-asterisk"></i>
     </div>
     <div class="form-group">
       <label for="friend_code">Friend Code</label>
-      <input [(ngModel)]="user.friend_code" id="friend_code" type="text" placeholder="0000-0000-0000">
+      <input [(ngModel)]="user.friend_code" name="friend_code" id="friend_code" type="text" placeholder="0000-0000-0000">
     </div>
     <button type="submit">Let's go! <i class="fa fa-long-arrow-right"></i></button>
     <p>Already have an account? <a class="link" [routerLink]="['Login']">Login here</a>!</p>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,46 @@
   "name": "pokedextracker.com",
   "version": "1.5.0",
   "dependencies": {
+    "@angular/common": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/common@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-2.0.0-rc.4.tgz"
+    },
+    "@angular/compiler": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/compiler@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-2.0.0-rc.4.tgz"
+    },
+    "@angular/core": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/core@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-2.0.0-rc.4.tgz"
+    },
+    "@angular/forms": {
+      "version": "0.2.0",
+      "from": "@angular/forms@0.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-0.2.0.tgz"
+    },
+    "@angular/http": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/http@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-2.0.0-rc.4.tgz"
+    },
+    "@angular/platform-browser": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/platform-browser@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-2.0.0-rc.4.tgz"
+    },
+    "@angular/platform-browser-dynamic": {
+      "version": "2.0.0-rc.4",
+      "from": "@angular/platform-browser-dynamic@2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-2.0.0-rc.4.tgz"
+    },
+    "@angular/router-deprecated": {
+      "version": "2.0.0-rc.2",
+      "from": "@angular/router-deprecated@latest",
+      "resolved": "https://registry.npmjs.org/@angular/router-deprecated/-/router-deprecated-2.0.0-rc.2.tgz"
+    },
     "abbrev": {
       "version": "1.0.7",
       "from": "abbrev@>=1.0.0 <1.1.0",
@@ -56,15 +96,10 @@
       "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
-    "angular2": {
-      "version": "2.0.0-beta.17",
-      "from": "angular2@latest",
-      "resolved": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.17.tgz"
-    },
     "angulartics2": {
-      "version": "1.0.10",
-      "from": "angulartics2@1.0.10",
-      "resolved": "https://registry.npmjs.org/angulartics2/-/angulartics2-1.0.10.tgz"
+      "version": "1.1.5",
+      "from": "angulartics2@1.1.5",
+      "resolved": "https://registry.npmjs.org/angulartics2/-/angulartics2-1.1.5.tgz"
     },
     "ansi": {
       "version": "0.3.1",
@@ -2625,11 +2660,6 @@
       "version": "3.0.0",
       "from": "minimatch@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,15 @@
     "typings": "typings"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.17",
-    "angulartics2": "^1.0.10",
+    "@angular/common": "^2.0.0-rc.4",
+    "@angular/compiler": "^2.0.0-rc.4",
+    "@angular/core": "^2.0.0-rc.4",
+    "@angular/forms": "^0.2.0",
+    "@angular/http": "^2.0.0-rc.4",
+    "@angular/platform-browser": "^2.0.0-rc.4",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.4",
+    "@angular/router-deprecated": "^2.0.0-rc.2",
+    "angulartics2": "^1.1.5",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
     <meta name="og:image" content="https://pokedextracker.com/og.png">
     <meta name="og:title" content="Pokédex Tracker">
     <meta name="og:description" content="A tool for tracking your Living Dex progress. Easily toggle between and track your captured Pokémon, find the locations of those left to be captured, and share a public link with others to see how you can help each other out.">
-    <script src="https://code.angularjs.org/2.0.0-beta.12/angular2-polyfills.js"></script>
+    <script src="https://code.angularjs.org/2.0.0-beta.17/angular2-polyfills.js"></script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en"></script>
     <script type="application/ld+json">
     {


### PR DESCRIPTION
ƪ(΄◞ิ۝◟ิ‵)ʃ

upgraaaaade! this one was quite a doozy. this currently isnt the latest rc (`rc.6` came out 8/31) but there was a huuuge change in structure from `rc.4` to `rc.5` so i thought id take things slow

changes include (for documentation purposes):

- getting rid of the `angular2` module in favor of `@angular/*`
- add `@angular2/forms@0.2.0` to move to the new way forms are being handled
  - add `disableDeprecatedForms` and `provideForms` to `boot.ts`
  - add `name` attributes to the any `input` element we had `ngModel` on
- `ngSwitchWhen` ➡️ `ngSwitchCase`
- upgrade `angulartics2` from `v1.0.10` to `v1.1.5` **though i still dont think page view tracking works, only event tracking. i think when we stop using the deprecated router, it will work again, but thatll be coming in another pr**
- pass around an html sanitizer so that we dont get a bunch of dumb warnings in the console. this was caused because we are using `[innerHTML]`. i _think_ we can actually get rid of all this stuff when we upgrade to `rc.5` because of [this commit](https://github.com/angular/angular/commit/482c019) but well see
- upgrade the polyfill url from `beta.12` to `beta.17`. i forgot to do this in the last upgrade pr but it looks like there arent hosted polyfill files for the `rc`s. i think we can use [this starter repo](https://github.com/angular/angular2-seed) to correctly load the polyfills/dependencies without the need of `angular2-polyfills.js`

before moving on to the other `rc`s, i wanna move to the new router cause i think the old deprecated one doesnt work with all the new stuff

@ami same as before, all you need to do is checkout the branch, `rm -rf node_modules`, `npm i`, `npm start`, and see if all of the pages/functionality still works!