### PR TITLE
fix(webpack): remove reference to istanbul-instrumenter

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,12 +31,7 @@ module.exports = {
       { test: /\.ts$/, loader: 'ts' },
       { test: /\.scss$/, loaders: ['style', 'css', 'sass'] },
       { test: /\.html/, loader: 'raw' }
-    ],
-    postLoaders: [{
-      test: /\.(js|ts)$/,
-      exclude: /(test|node_modules)\//,
-      loader: 'istanbul-instrumenter'
-    }]
+    ]
   },
   plugins: PLUGINS
 };


### PR DESCRIPTION
( ≧Д≦)

forgot this in #152 ...oops