### PR TITLE
fix(spinner): hide content when spinning

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -47,6 +47,10 @@ a.link {
   }
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 nav {
   @include flexbox();
   @include flex(0 0 42px);
@@ -85,6 +89,7 @@ button {
   @include transition(all .1s ease-out);
 
   display: block;
+  position: relative;
   width: 100%;
   height: 43px;
   border: 0;
@@ -106,6 +111,22 @@ button {
 
     font-size: 10px;
     margin-left: 3px;
+  }
+
+  .spinner {
+    @include flexbox();
+    @include align-items(center);
+    @include justify-content(center);
+
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    .fa {
+      margin: 0;
+    }
   }
 }
 

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -509,32 +509,11 @@ box {
     }
 
     button {
-      position: relative;
       display: inline-block;
       height: auto;
       width: auto;
       padding: 8px 12px;
       font-size: 10px;
-
-      .spinner {
-        @include flexbox();
-        @include align-items(center);
-        @include justify-content(center);
-
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
-
-        .fa {
-          margin: 0;
-        }
-      }
-
-      .hidden {
-        visibility: hidden;
-      }
     }
   }
 


### PR DESCRIPTION
(๑ˇ ῁̫ ˇ)˒˒
^ smug 🐛  catching face

the disabled spinner button on the account page wasn't actually working as expected b/c all the styles for it were nested under `box .box-header button`. 