### PR TITLE
fix(polyfill): add babel-polyfill

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -549,6 +549,23 @@
       "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz"
     },
+    "babel-polyfill": {
+      "version": "6.5.0",
+      "from": "babel-polyfill@6.5.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.5.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "from": "babel-runtime@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz"
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.14.0",
       "from": "babel-preset-es2015@*",
@@ -578,6 +595,11 @@
       "version": "6.11.0",
       "from": "babel-preset-stage-3@>=6.11.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.11.0.tgz"
+    },
+    "babel-regenerator-runtime": {
+      "version": "6.5.0",
+      "from": "babel-regenerator-runtime@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-regenerator-runtime/-/babel-regenerator-runtime-6.5.0.tgz"
     },
     "babel-register": {
       "version": "6.14.0",
@@ -2723,6 +2745,11 @@
       "version": "3.7.0",
       "from": "raven-js@*",
       "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.7.0.tgz"
+    },
+    "raw-loader": {
+      "version": "0.5.1",
+      "from": "raw-loader@*",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz"
     },
     "react": {
       "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.5",
+    "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
@@ -47,6 +48,7 @@
     "eslint-plugin-react": "^6.3.0",
     "generate-changelog": "^1.0.0",
     "node-sass": "^3.10.0",
+    "raw-loader": "^0.5.1",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ if (PRODUCTION) {
 
 module.exports = {
   context: Path.join(__dirname, 'app'),
-  entry: './index.jsx',
+  entry: ['babel-polyfill', './index.jsx'],
   output: {
     path: `${__dirname}/public`,
     filename: 'bundle.js'


### PR DESCRIPTION
ฅ(*°ω°*ฅ)

fixes #190 

right now, master is broken for ie 11 (and others). this fixes that! i tested it with my vm! it provides a Promise polyfill and i _think_ a localStorage polyfill too (we've had a few issues with that too).

i also saved the `raw-loader` in the package.json and the shrinkwrap. not sure why it wasnt there before... ¯\\\_(ツ)_/¯