### PR TITLE
fix(scroll): check if _dex exists

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,6 @@
     "key-spacing": [2, { "beforeColon": false, "afterColon": true, "mode": "strict" }],
     "linebreak-style": [2, "unix"],
     "new-parens": 2,
-    "no-confusing-arrow": 2,
     "no-caller": 2,
     "no-catch-shadow": 2,
     "no-class-assign": 2,

--- a/app/components/dex.jsx
+++ b/app/components/dex.jsx
@@ -12,9 +12,9 @@ export class Dex extends Component {
   onScroll = () => {
     const { setShowScroll, showScroll } = this.props;
 
-    if (!showScroll && this._dex.scrollTop >= SHOW_SCROLL_THRESHOLD) {
+    if (!showScroll && this._dex && this._dex.scrollTop >= SHOW_SCROLL_THRESHOLD) {
       setShowScroll(true);
-    } else if (showScroll && this._dex.scrollTop < SHOW_SCROLL_THRESHOLD) {
+    } else if (showScroll && this._dex && this._dex.scrollTop < SHOW_SCROLL_THRESHOLD) {
       setShowScroll(false);
     }
   }
@@ -31,7 +31,7 @@ export class Dex extends Component {
 
     return (
       <div className="dex" ref={(c) => this._dex = c} onScroll={throttle(this.onScroll, SCROLL_DEBOUNCE)}>
-        <ScrollComponent onClick={() => this._dex.scrollTop = 0} />
+        <ScrollComponent onClick={() => this._dex ? this._dex.scrollTop = 0 : null} />
         <HeaderComponent />
         {groups.map((group) => <BoxComponent key={group[0].pokemon.national_id} captures={group} />)}
       </div>


### PR DESCRIPTION
(*′☉.̫☉)

fixes #191 

as the issue says, there is a weird occurrence where `this._dex` is `null`. this just checks to make sure that it exists first.

also i dont like the `no-confusing-arrow` rule. its dumb. so i removed it! :radioactive: 