### PR TITLE
fix(load): wait for DOMContentLoaded if necessary

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -6,9 +6,17 @@ import { render }   from 'react-dom';
 import { AppComponent } from './components/app';
 import { Store }        from './stores';
 
-render(
-  <Provider store={Store}>
-    <AppComponent />
-  </Provider>,
-  document.getElementById('root')
-);
+function run () {
+  render(
+    <Provider store={Store}>
+      <AppComponent />
+    </Provider>,
+    document.getElementById('root')
+  );
+}
+
+if (document.getElementById('root')) {
+  run();
+} else {
+  window.addEventListener('DOMContentLoaded', run);
+}


### PR DESCRIPTION
(◍˃̶ᗜ˂̶◍)ﾉ”

fixes #192 

as mentioned in the issue, it should wait for the dom to be loaded before trying to load react cause if you try to do so before, it errs out. this should fix that by waiting for `DOMContentLoaded`.