### PR TITLE
feat(dexes): add dex settings to signup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
 sudo: false
+env: 'CXX=g++-4.8'
 node_js:
   - '5'
   - '6'
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
 script:
   - npm run lint
   - npm run fsevents

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,4 +1,5 @@
 import { push } from 'react-router-redux';
+import slug     from 'slug';
 
 import { Config }       from '../../config';
 import { API }          from '../utils/api';
@@ -20,7 +21,7 @@ export function createUser ({ username, password, password_confirm, friend_code,
     })
     .then(({ token }) => {
       dispatch(setToken(token));
-      dispatch(push(`/u/${username}`));
+      dispatch(push(`/u/${username}/${slug(title, { lower: true })}`));
     });
   };
 }

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -8,7 +8,7 @@ import { setToken }     from './session';
 export const SET_USER         = 'SET_USER';
 export const SET_CURRENT_USER = 'SET_CURRENT_USER';
 
-export function createUser ({ username, password, password_confirm, friend_code }) {
+export function createUser ({ username, password, password_confirm, friend_code, title, shiny, generation }) {
   return (dispatch) => {
     return Promise.resolve()
     .then(() => {
@@ -16,7 +16,7 @@ export function createUser ({ username, password, password_confirm, friend_code 
         throw new Error('passwords need to match');
       }
 
-      return API.post(`${Config.API_HOST}/users`, { username, password, friend_code, referrer: document.referrer });
+      return API.post(`${Config.API_HOST}/users`, { username, password, friend_code, referrer: document.referrer, title, shiny, generation });
     })
     .then(({ token }) => {
       dispatch(setToken(token));

--- a/app/components/account.jsx
+++ b/app/components/account.jsx
@@ -36,6 +36,12 @@ export class Account extends Component {
     checkVersion();
   }
 
+  scrollToTop () {
+    if (this._form) {
+      this._form.scrollTop = 0;
+    }
+  }
+
   onSubmit = (e) => {
     e.preventDefault();
 
@@ -57,7 +63,10 @@ export class Account extends Component {
 
       this.setState({ ...this.state, loading: false, success: 'Account settings saved!' });
     })
-    .catch((err) => this.setState({ ...this.state, error: err.message, loading: false }));
+    .catch((err) => {
+      this.setState({ ...this.state, error: err.message, loading: false });
+      this.scrollToTop();
+    });
   }
 
   render () {
@@ -90,7 +99,7 @@ export class Account extends Component {
         <div className="account-container">
           <NavComponent />
           <ReloadComponent />
-          <div className="form">
+          <div className="form" ref={(c) => this._form = c}>
             <h1>{session.username}'s Account</h1>
             <form onSubmit={this.onSubmit}>
               <div className="form-column">

--- a/app/components/account.jsx
+++ b/app/components/account.jsx
@@ -93,30 +93,32 @@ export class Account extends Component {
           <div className="form">
             <h1>{session.username}'s Account</h1>
             <form onSubmit={this.onSubmit}>
-              <AlertComponent message={error} type="error" />
-              <AlertComponent message={success} type="success" />
-              <div className="form-group">
-                <label htmlFor="password">Password</label>
-                <button className="btn btn-inline btn-yellow" type="button" onClick={() => this.setState({ ...this.state, password: !password })}>
-                  {password ? 'Cancel' : 'Change'}
+              <div className="form-column">
+                <AlertComponent message={error} type="error" />
+                <AlertComponent message={success} type="success" />
+                <div className="form-group">
+                  <label htmlFor="password">Password</label>
+                  <button className="btn btn-inline btn-yellow" type="button" onClick={() => this.setState({ ...this.state, password: !password })}>
+                    {password ? 'Cancel' : 'Change'}
+                  </button>
+                </div>
+                {passwordInputs}
+                <div className="form-group">
+                  <label htmlFor="friend_code">Friend Code</label>
+                  <input className="form-control" ref={(c) => this._friend_code = c} defaultValue={session.friend_code} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="language">Pokémon Name Language</label>
+                  <select className="form-control">
+                    <option>English</option>
+                  </select>
+                  <i className="fa fa-chevron-down" />
+                </div>
+                <button className="btn btn-blue" type="submit">
+                  <span className={loading ? 'hidden' : ''}>Save <i className="fa fa-long-arrow-right" /></span>
+                  {loading ? <span className="spinner"><i className="fa fa-spinner fa-spin" /></span> : null}
                 </button>
               </div>
-              {passwordInputs}
-              <div className="form-group">
-                <label htmlFor="friend_code">Friend Code</label>
-                <input className="form-control" ref={(c) => this._friend_code = c} defaultValue={session.friend_code} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
-              </div>
-              <div className="form-group">
-                <label htmlFor="language">Pokémon Name Language</label>
-                <select className="form-control">
-                  <option>English</option>
-                </select>
-                <i className="fa fa-chevron-down" />
-              </div>
-              <button className="btn btn-blue" type="submit">
-                <span className={loading ? 'hidden' : ''}>Save <i className="fa fa-long-arrow-right" /></span>
-                {loading ? <span className="spinner"><i className="fa fa-spinner fa-spin" /></span> : null}
-              </button>
             </form>
           </div>
         </div>

--- a/app/components/account.jsx
+++ b/app/components/account.jsx
@@ -74,11 +74,11 @@ export class Account extends Component {
       passwordInputs = (
         <div>
           <div className="form-group">
-            <input ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
+            <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
             <i className="fa fa-asterisk" />
           </div>
           <div className="form-group">
-            <input ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
+            <input className="form-control" ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
             <i className="fa fa-asterisk" />
           </div>
         </div>
@@ -104,11 +104,11 @@ export class Account extends Component {
               {passwordInputs}
               <div className="form-group">
                 <label htmlFor="friend_code">Friend Code</label>
-                <input ref={(c) => this._friend_code = c} defaultValue={session.friend_code} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
+                <input className="form-control" ref={(c) => this._friend_code = c} defaultValue={session.friend_code} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
               </div>
               <div className="form-group">
                 <label htmlFor="language">Pokémon Name Language</label>
-                <select>
+                <select className="form-control">
                   <option>English</option>
                 </select>
                 <i className="fa fa-chevron-down" />

--- a/app/components/evolution-family.jsx
+++ b/app/components/evolution-family.jsx
@@ -4,7 +4,7 @@ import { EvolutionsComponent } from './evolutions';
 import { iconClass }           from '../utils/pokemon';
 import { setCurrentPokemon }   from '../actions/pokemon';
 
-export function EvolutionFamily ({ family, setCurrentPokemon }) {
+export function EvolutionFamily ({ dex, family, setCurrentPokemon }) {
   let column1 = null;
   let column2 = null;
 
@@ -12,7 +12,7 @@ export function EvolutionFamily ({ family, setCurrentPokemon }) {
     column1 = (
       <div className="evolution-pokemon-column">
         {family.pokemon[1].map((pokemon, i) => <a key={i} onClick={() => setCurrentPokemon(pokemon.national_id)}>
-          <i className={iconClass(pokemon.national_id)} />
+          <i className={iconClass(pokemon.national_id, dex.shiny)} />
         </a>)}
       </div>
     );
@@ -22,7 +22,7 @@ export function EvolutionFamily ({ family, setCurrentPokemon }) {
     column2 = (
       <div className="evolution-pokemon-column">
         {family.pokemon[2].map((pokemon, i) => <a key={i} onClick={() => setCurrentPokemon(pokemon.national_id)}>
-          <i className={iconClass(pokemon.national_id)} />
+          <i className={iconClass(pokemon.national_id, dex.shiny)} />
         </a>)}
       </div>
     );
@@ -32,7 +32,7 @@ export function EvolutionFamily ({ family, setCurrentPokemon }) {
     <div className="info-evolutions">
       <div className="evolution-pokemon-column">
         <a onClick={() => setCurrentPokemon(family.pokemon[0][0].national_id)}>
-          <i className={iconClass(family.pokemon[0][0].national_id)} />
+          <i className={iconClass(family.pokemon[0][0].national_id, dex.shiny)} />
         </a>
         {family.evolutions.length === 0 ? <div>Does not evolve</div> : null}
       </div>
@@ -44,10 +44,14 @@ export function EvolutionFamily ({ family, setCurrentPokemon }) {
   );
 }
 
+function mapStateToProps ({ currentDex, currentUser, users }) {
+  return { dex: users[currentUser].dexesBySlug[currentDex] };
+}
+
 function mapDispatchToProps (dispatch) {
   return {
     setCurrentPokemon: (id) => dispatch(setCurrentPokemon(id))
   };
 }
 
-export const EvolutionFamilyComponent = connect(null, mapDispatchToProps)(EvolutionFamily);
+export const EvolutionFamilyComponent = connect(mapStateToProps, mapDispatchToProps)(EvolutionFamily);

--- a/app/components/home.jsx
+++ b/app/components/home.jsx
@@ -9,10 +9,10 @@ import { checkVersion } from '../actions/utils';
 export class Home extends Component {
 
   componentWillMount () {
-    const { checkVersion, redirectToTracker, session } = this.props;
+    const { checkVersion, redirectToProfile, session } = this.props;
 
     if (session) {
-      redirectToTracker(session.username);
+      redirectToProfile(session.username);
     }
 
     checkVersion();
@@ -58,7 +58,7 @@ function mapStateToProps ({ session }) {
 function mapDispatchToProps (dispatch) {
   return {
     checkVersion: () => dispatch(checkVersion()),
-    redirectToTracker: (username) => dispatch(push(`/u/${username}`))
+    redirectToProfile: (username) => dispatch(push(`/u/${username}`))
   };
 }
 

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -35,7 +35,7 @@ export class Info extends Component {
   }
 
   render () {
-    const { pokemon, showInfo } = this.props;
+    const { dex, pokemon, showInfo } = this.props;
 
     if (!pokemon) {
       return (
@@ -57,7 +57,7 @@ export class Info extends Component {
 
         <div className="info-main">
           <div className="info-header">
-            <i className={iconClass(pokemon.national_id)} />
+            <i className={iconClass(pokemon.national_id, dex.shiny)} />
             <h1 dangerouslySetInnerHTML={htmlName(pokemon.name)}></h1>
             <h2>#{padding(pokemon.national_id, 3)}</h2>
           </div>
@@ -94,8 +94,8 @@ export class Info extends Component {
 
 }
 
-function mapStateToProps ({ currentPokemon, pokemon, showInfo }) {
-  return { currentPokemon, pokemon: pokemon[currentPokemon], showInfo };
+function mapStateToProps ({ currentDex, currentUser, currentPokemon, pokemon, showInfo, users }) {
+  return { currentPokemon, dex: users[currentUser].dexesBySlug[currentDex], pokemon: pokemon[currentPokemon], showInfo };
 }
 
 function mapDispatchToProps (dispatch) {

--- a/app/components/login.jsx
+++ b/app/components/login.jsx
@@ -19,10 +19,10 @@ export class Login extends Component {
   }
 
   componentWillMount () {
-    const { checkVersion, redirectToTracker, session } = this.props;
+    const { checkVersion, redirectToProfile, session } = this.props;
 
     if (session) {
-      redirectToTracker(session.username);
+      redirectToProfile(session.username);
     }
 
     checkVersion();
@@ -53,19 +53,21 @@ export class Login extends Component {
           <div className="form">
             <h1>Login</h1>
             <form onSubmit={this.login}>
-              <AlertComponent message={error} type="error" />
-              <div className="form-group">
-                <label htmlFor="username">Username</label>
-                <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
-                <i className="fa fa-asterisk" />
+              <div className="form-column">
+                <AlertComponent message={error} type="error" />
+                <div className="form-group">
+                  <label htmlFor="username">Username</label>
+                  <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="cabrioles" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
+                  <i className="fa fa-asterisk" />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="password">Password</label>
+                  <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" maxLength="72" />
+                  <i className="fa fa-asterisk" />
+                </div>
+                <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>
+                <p>Don't have an account yet? <Link className="link" to="/register">Register here</Link>!</p>
               </div>
-              <div className="form-group">
-                <label htmlFor="password">Password</label>
-                <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" maxLength="72" />
-                <i className="fa fa-asterisk" />
-              </div>
-              <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>
-              <p>Don't have an account yet? <Link className="link" to="/register">Register here</Link>!</p>
             </form>
           </div>
         </div>
@@ -83,7 +85,7 @@ function mapDispatchToProps (dispatch) {
   return {
     checkVersion: () => dispatch(checkVersion()),
     login: (payload) => dispatch(login(payload)),
-    redirectToTracker: (username) => dispatch(push(`/u/${username}`))
+    redirectToProfile: (username) => dispatch(push(`/u/${username}`))
   };
 }
 

--- a/app/components/login.jsx
+++ b/app/components/login.jsx
@@ -57,7 +57,7 @@ export class Login extends Component {
                 <AlertComponent message={error} type="error" />
                 <div className="form-group">
                   <label htmlFor="username">Username</label>
-                  <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="cabrioles" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
+                  <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
                   <i className="fa fa-asterisk" />
                 </div>
                 <div className="form-group">

--- a/app/components/login.jsx
+++ b/app/components/login.jsx
@@ -56,12 +56,12 @@ export class Login extends Component {
               <AlertComponent message={error} type="error" />
               <div className="form-group">
                 <label htmlFor="username">Username</label>
-                <input ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
+                <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" maxLength="20" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
                 <i className="fa fa-asterisk" />
               </div>
               <div className="form-group">
                 <label htmlFor="password">Password</label>
-                <input ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" maxLength="72" />
+                <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" maxLength="72" />
                 <i className="fa fa-asterisk" />
               </div>
               <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>

--- a/app/components/login.jsx
+++ b/app/components/login.jsx
@@ -28,6 +28,12 @@ export class Login extends Component {
     checkVersion();
   }
 
+  scrollToTop () {
+    if (this._form) {
+      this._form.scrollTop = 0;
+    }
+  }
+
   login = (e) => {
     e.preventDefault();
 
@@ -39,7 +45,10 @@ export class Login extends Component {
 
     login({ username, password })
     .then(() => ReactGA.event({ action: 'login', category: 'Session' }))
-    .catch((err) => this.setState({ ...this.state, error: err.message }));
+    .catch((err) => {
+      this.setState({ ...this.state, error: err.message });
+      this.scrollToTop();
+    });
   }
 
   render () {
@@ -50,7 +59,7 @@ export class Login extends Component {
         <div className="login-container">
           <NavComponent />
           <ReloadComponent />
-          <div className="form">
+          <div className="form" ref={(c) => this._form = c}>
             <h1>Login</h1>
             <form onSubmit={this.login}>
               <div className="form-column">

--- a/app/components/pokemon.jsx
+++ b/app/components/pokemon.jsx
@@ -51,7 +51,7 @@ export class Pokemon extends Component {
   }
 
   render () {
-    const { capture, region, session, user } = this.props;
+    const { capture, dex, region, session, user } = this.props;
 
     if (!capture) {
       return (
@@ -73,11 +73,11 @@ export class Pokemon extends Component {
       <div className={classNames(classes)}>
         <div className="set-captured" onClick={this.toggleCaptured}>
           <h4 dangerouslySetInnerHTML={htmlName(capture.pokemon.name)} />
-          <i className={iconClass(capture.pokemon.national_id)} />
+          <i className={iconClass(capture.pokemon.national_id, dex.shiny)} />
           <p>#{padding(capture.pokemon.national_id, 3)}</p>
         </div>
         <div className="set-captured-mobile" onClick={this.toggleCaptured}>
-          <i className={iconClass(capture.pokemon.national_id)} />
+          <i className={iconClass(capture.pokemon.national_id, dex.shiny)} />
           <h4 dangerouslySetInnerHTML={htmlName(capture.pokemon.name)} />
           <p>#{padding(capture.pokemon.national_id, 3)}</p>
         </div>

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -96,8 +96,8 @@ export class Register extends Component {
                     </div>
                   </h2>
                   <div className="form-group">
-                    <label htmlFor="dex_name">Name</label>
-                    <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" required placeholder="Living Dex" />
+                    <label htmlFor="dex_title">Title</label>
+                    <input className="form-control" ref={(c) => this._title = c} name="dex_title" id="dex_title" type="text" required placeholder="Living Dex" />
                     <i className="fa fa-asterisk" />
                   </div>
                   <div className="form-group">

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -20,10 +20,10 @@ export class Register extends Component {
   }
 
   componentWillMount () {
-    const { checkVersion, redirectToTracker, session } = this.props;
+    const { checkVersion, redirectToProfile, session } = this.props;
 
     if (session) {
-      redirectToTracker(session.username);
+      redirectToProfile(session.username);
     }
 
     checkVersion();
@@ -59,66 +59,76 @@ export class Register extends Component {
           <div className="form register">
             <h1>Register</h1>
             <form onSubmit={this.register}>
-              <AlertComponent message={error} type="error" />
-
-              <h2>Account Info</h2>
-              <div className="form-group">
-                <label htmlFor="username">Username</label>
-                <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
-                <i className="fa fa-asterisk" />
-              </div>
-              <div className="form-group">
-                <label htmlFor="password">Password</label>
-                <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
-                <i className="fa fa-asterisk" />
-              </div>
-              <div className="form-group">
-                <label htmlFor="password_confirm">Confirm Password</label>
-                <input className="form-control" ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
-                <i className="fa fa-asterisk" />
-              </div>
-              <div className="form-group">
-                <label htmlFor="friend_code">Friend Code</label>
-                <input className="form-control" ref={(c) => this._friend_code = c} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
+              <div className="form-column">
+                <AlertComponent message={error} type="error" />
               </div>
 
-              <h2>
-                First Dex Info
-                <div className="tooltip">
-                  <i className="fa fa-plus-circle" />
-                  <span className="tooltip-text">You can track multiple dexes on our app! This sets the settings for the first dex on your account.</span>
+              <div className="form-row">
+                <div className="form-column">
+                  <h2>Account Info</h2>
+                  <div className="form-group">
+                    <label htmlFor="username">Username</label>
+                    <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
+                    <i className="fa fa-asterisk" />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="password">Password</label>
+                    <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
+                    <i className="fa fa-asterisk" />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="password_confirm">Confirm Password</label>
+                    <input className="form-control" ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
+                    <i className="fa fa-asterisk" />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="friend_code">Friend Code</label>
+                    <input className="form-control" ref={(c) => this._friend_code = c} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
+                  </div>
                 </div>
-              </h2>
-              <div className="form-group">
-                <label htmlFor="dex_name">Name</label>
-                <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" required placeholder="Living Dex" />
-                <i className="fa fa-asterisk" />
-              </div>
-              <div className="form-group">
-                <label htmlFor="type">Type</label>
-                <div className="radio">
-                  <label>
-                    <input type="radio" name="type" defaultChecked />
-                    <span className="radio-custom"><span></span></span>Normal
-                  </label>
+
+                <div className="form-column">
+                  <h2>
+                    First Dex Info
+                    <div className="tooltip">
+                      <i className="fa fa-question-circle" />
+                      <span className="tooltip-text">You can track multiple dexes on our app! This sets the settings for the first dex on your account.</span>
+                    </div>
+                  </h2>
+                  <div className="form-group">
+                    <label htmlFor="dex_name">Name</label>
+                    <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" required placeholder="Living Dex" />
+                    <i className="fa fa-asterisk" />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="generation">Generation</label>
+                    <select className="form-control" ref={(c) => this._generation = c} defaultValue="6">
+                      <option value="6">Six</option>
+                    </select>
+                    <i className="fa fa-chevron-down" />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="type">Type</label>
+                    <div className="radio">
+                      <label>
+                        <input type="radio" name="type" defaultChecked />
+                        <span className="radio-custom"><span></span></span>Normal
+                      </label>
+                    </div>
+                    <div className="radio">
+                      <label>
+                        <input ref={(c) => this._shiny = c} type="radio" name="type" />
+                        <span className="radio-custom"><span></span></span>Shiny
+                      </label>
+                    </div>
+                  </div>
                 </div>
-                <div className="radio">
-                  <label>
-                    <input ref={(c) => this._shiny = c} type="radio" name="type" />
-                    <span className="radio-custom"><span></span></span>Shiny
-                  </label>
-                </div>
-              </div>
-              <div className="form-group">
-                <label htmlFor="generation">Generation</label>
-                <select className="form-control" ref={(c) => this._generation = c} defaultValue="6">
-                  <option value="6">Six</option>
-                </select>
-                <i className="fa fa-chevron-down" />
               </div>
 
-              <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>
-              <p>Already have an account? <Link className="link" to="/login">Login here</Link>!</p>
+              <div className="form-column">
+                <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>
+                <p>Already have an account? <Link className="link" to="/login">Login here</Link>!</p>
+              </div>
             </form>
           </div>
         </div>
@@ -136,7 +146,7 @@ function mapDispatchToProps (dispatch) {
   return {
     checkVersion: () => dispatch(checkVersion()),
     register: (payload) => dispatch(createUser(payload)),
-    redirectToTracker: (username) => dispatch(push(`/u/${username}`))
+    redirectToProfile: (username) => dispatch(push(`/u/${username}/`))
   };
 }
 

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -37,10 +37,13 @@ export class Register extends Component {
     const password = this._password.value;
     const password_confirm = this._password_confirm.value;
     const friend_code = this._friend_code.value;
+    const title = this._title.value;
+    const shiny = this._shiny.checked;
+    const generation = this._generation.value;
 
     this.setState({ ...this.state, error: null });
 
-    register({ username, password, password_confirm, friend_code })
+    register({ username, password, password_confirm, friend_code, title, shiny, generation })
     .then(() => ReactGA.event({ action: 'register', category: 'Session' }))
     .catch((err) => this.setState({ ...this.state, error: err.message }));
   }
@@ -53,29 +56,66 @@ export class Register extends Component {
         <div className="register-container">
           <NavComponent />
           <ReloadComponent />
-          <div className="form">
+          <div className="form register">
             <h1>Register</h1>
             <form onSubmit={this.register}>
               <AlertComponent message={error} type="error" />
+
+              <h2>Account Info</h2>
               <div className="form-group">
                 <label htmlFor="username">Username</label>
-                <input ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
+                <input className="form-control" ref={(c) => this._username = c} name="username" id="username" type="text" required placeholder="ashketchum10" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" />
                 <i className="fa fa-asterisk" />
               </div>
               <div className="form-group">
                 <label htmlFor="password">Password</label>
-                <input ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
+                <input className="form-control" ref={(c) => this._password = c} name="password" id="password" type="password" required placeholder="••••••••••••" />
                 <i className="fa fa-asterisk" />
               </div>
               <div className="form-group">
                 <label htmlFor="password_confirm">Confirm Password</label>
-                <input ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
+                <input className="form-control" ref={(c) => this._password_confirm = c} name="password_confirm" id="password_confirm" type="password" required placeholder="••••••••••••" />
                 <i className="fa fa-asterisk" />
               </div>
               <div className="form-group">
                 <label htmlFor="friend_code">Friend Code</label>
-                <input ref={(c) => this._friend_code = c} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
+                <input className="form-control" ref={(c) => this._friend_code = c} name="friend_code" id="friend_code" type="text" placeholder="XXXX-XXXX-XXXX" onChange={(e) => this._friend_code.value = friendCode(e.target.value)} />
               </div>
+
+              <h2>
+                First Dex Info
+                <div className="tooltip">
+                  <i className="fa fa-plus-circle" />
+                  <span className="tooltip-text">You can track multiple dexes on our app! This sets the settings for the first dex on your account.</span>
+                </div>
+              </h2>
+              <div className="form-group">
+                <label htmlFor="dex_name">Name</label>
+                <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" placeholder="Living Dex" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="type">Type</label>
+                <div className="radio">
+                  <label>
+                    <input type="radio" name="type" defaultChecked />
+                    <span className="radio-custom"><span></span></span>Normal
+                  </label>
+                </div>
+                <div className="radio">
+                  <label>
+                    <input ref={(c) => this._shiny = c} type="radio" name="type" />
+                    <span className="radio-custom"><span></span></span>Shiny
+                  </label>
+                </div>
+              </div>
+              <div className="form-group">
+                <label htmlFor="generation">Generation</label>
+                <select className="form-control" ref={(c) => this._generation = c} defaultValue="6">
+                  <option value="6">Six</option>
+                </select>
+                <i className="fa fa-chevron-down" />
+              </div>
+
               <button className="btn btn-blue" type="submit">Let's go! <i className="fa fa-long-arrow-right" /></button>
               <p>Already have an account? <Link className="link" to="/login">Login here</Link>!</p>
             </form>

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -91,7 +91,8 @@ export class Register extends Component {
               </h2>
               <div className="form-group">
                 <label htmlFor="dex_name">Name</label>
-                <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" placeholder="Living Dex" />
+                <input className="form-control" ref={(c) => this._title = c} name="dex_name" id="dex_name" type="text" required placeholder="Living Dex" />
+                <i className="fa fa-asterisk" />
               </div>
               <div className="form-group">
                 <label htmlFor="type">Type</label>

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -29,6 +29,12 @@ export class Register extends Component {
     checkVersion();
   }
 
+  scrollToTop () {
+    if (this._form) {
+      this._form.scrollTop = 0;
+    }
+  }
+
   register = (e) => {
     e.preventDefault();
 
@@ -45,7 +51,10 @@ export class Register extends Component {
 
     register({ username, password, password_confirm, friend_code, title, shiny, generation })
     .then(() => ReactGA.event({ action: 'register', category: 'Session' }))
-    .catch((err) => this.setState({ ...this.state, error: err.message }));
+    .catch((err) => {
+      this.setState({ ...this.state, error: err.message });
+      this.scrollToTop();
+    });
   }
 
   render () {
@@ -56,7 +65,7 @@ export class Register extends Component {
         <div className="register-container">
           <NavComponent />
           <ReloadComponent />
-          <div className="form register">
+          <div className="form register" ref={(c) => this._form = c}>
             <h1>Register</h1>
             <form onSubmit={this.register}>
               <div className="form-column">

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -182,27 +182,35 @@ nav {
   }
 }
 
-.login-container {
-  padding-bottom: 150px;
-}
-
 .form {
   @include flex-grow(1);
   @include flexbox();
   @include flex-direction(column);
-  @include justify-content(center);
+  @include overflow-y-scroll;
   @include align-items(center);
+
+  padding: 50px 0 100px;
 
   h1 {
     color: $brand-secondary;
     margin-bottom: 17px;
   }
 
-  &.register {
-    @include overflow-y-scroll;
-    @include justify-content(flex-start);
+  .form-column {
+    width: 280px;
+    margin: 0 auto;
+  }
 
-    padding: 50px 0 100px;
+  .form-row {
+    @include flexbox();
+
+    .form-column {
+      margin: 0 15px;
+    }
+
+    .form-group:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -211,7 +219,6 @@ form {
 
   position: relative;
   top: 60px;
-  width: 280px;
 
   h2 {
     text-align: center;
@@ -273,8 +280,8 @@ select {
 
   .form-control,
   select {
-    height: 42px;
-    padding: 12px 32px 10px 10px;
+    height: 43px;
+    padding: 0 32px 0 10px;
     font-size: 15px;
 
     &[type="password"] {
@@ -351,7 +358,7 @@ select {
   position: relative;
   margin-left: 3px;
 
-  .fa-plus-circle {
+  .fa {
     font-size: 11px;
     color: $brand-secondary;
   }
@@ -477,5 +484,15 @@ reload div {
 @media (max-width: 700px) {
   .not-found h1 {
     font-size: 35px;
+  }
+}
+
+@media (max-width: 600px) {
+  .form .form-row {
+    display: block;
+
+    .form-group:last-child {
+      margin-bottom: 25px;
+    }
   }
 }

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -182,7 +182,63 @@ nav {
   }
 }
 
-input,
+.login-container {
+  padding-bottom: 150px;
+}
+
+.form {
+  @include flex-grow(1);
+  @include flexbox();
+  @include flex-direction(column);
+  @include justify-content(center);
+  @include align-items(center);
+
+  h1 {
+    color: $brand-secondary;
+    margin-bottom: 17px;
+  }
+
+  &.register {
+    @include overflow-y-scroll;
+    @include justify-content(flex-start);
+
+    padding: 50px 0 100px;
+  }
+}
+
+form {
+  @include animation(slide .5s ease-out forwards);
+
+  position: relative;
+  top: 60px;
+  width: 280px;
+
+  h2 {
+    text-align: center;
+    margin: 30px 0 15px;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    .tooltip {
+      margin-left: 7px;
+      bottom: 3px;
+    }
+  }
+
+  p {
+    margin: 20px 0 0;
+    text-align: center;
+    font-size: 14px;
+  }
+
+  .btn:not(.btn-inline) {
+    margin-top: 40px;
+  }
+}
+
+.form-control,
 select {
   width: 100%;
   -webkit-appearance: none;
@@ -201,77 +257,135 @@ select {
   }
 }
 
-.login-container {
-  padding-bottom: 150px;
-}
+.form-group {
+  position: relative;
+  margin-bottom: 25px;
 
-.form {
-  @include flex-grow(1);
-  @include flexbox();
-  @include flex-direction(column);
-  @include justify-content(center);
-  @include align-items(center);
+  label {
+    display: block;
+    margin-bottom: 7px;
+    font-family: $font-secondary;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
 
-  h1 {
+  .form-control,
+  select {
+    height: 42px;
+    padding: 12px 32px 10px 10px;
+    font-size: 15px;
+
+    &[type="password"] {
+      font-family: $font-secondary;
+    }
+  }
+
+  .radio {
+    display: inline-block;
+    margin: 0 13px;
+
+    label {
+      font-family: $font-primary;
+      text-transform: none;
+      font-size: 15px;
+      font-weight: 400;
+      letter-spacing: 0;
+      margin-bottom: 0;
+      cursor: pointer;
+    }
+
+    input[type=radio] {
+      display: none;
+
+      &:checked+.radio-custom span {
+        opacity: 1;
+      }
+    }
+
+    .radio-custom {
+      display: inline-block;
+      position: relative;
+      top: 3px;
+      right: 7px;
+      width: 16px;
+      height: 16px;
+      border: 1px solid $gray-medium;
+      background-color: lighten($gray-light, 25%);
+      border-radius: 50%;
+
+      > span {
+        @include transition(all .15s ease-out);
+        display: inline-block;
+        opacity: 0;
+        position: absolute;
+        background-color: $brand-primary;
+        border-radius: 50%;
+        height: 10px;
+        width: 10px;
+        top: 50%;
+        left: 50%;
+        margin: -5px 0 0 -5px;
+      }
+    }
+  }
+
+  .fa {
+    position: absolute;
+    bottom: 15px;
+    right: 15px;
+    font-size: 10px;
+    color: $brand-primary;
+  }
+
+  .fa-chevron-down {
+    bottom: 17px;
+    font-size: 9px;
     color: $brand-secondary;
   }
 }
 
-form {
-  @include animation(slide .5s ease-out forwards);
-
+.tooltip {
+  display: inline-block;
   position: relative;
-  top: 60px;
-  width: 280px;
+  margin-left: 3px;
 
-  .form-group {
-    position: relative;
-    margin-bottom: 25px;
-
-    label {
-      display: block;
-      margin-bottom: 7px;
-      font-family: $font-secondary;
-      font-size: 11px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 1px;
-    }
-
-    input,
-    select {
-      height: 43px;
-      padding: 10px 32px 10px 10px;
-      font-size: 15px;
-
-      &[type="password"] {
-        font-family: $font-secondary;
-      }
-    }
-
-    .fa {
-      position: absolute;
-      bottom: 15px;
-      right: 15px;
-      font-size: 10px;
-      color: $brand-primary;
-    }
-
-    .fa-chevron-down {
-      bottom: 17px;
-      font-size: 9px;
-      color: $brand-secondary;
-    }
+  .fa-plus-circle {
+    font-size: 11px;
+    color: $brand-secondary;
   }
 
-  p {
-    margin: 20px 0 0;
+  .tooltip-text {
+    visibility: hidden;
+    position: absolute;
+    bottom: 27px;
+    left: 50%;
+    margin-left: -($tooltip-width / 2);
+    z-index: 1;
+    width: $tooltip-width;
+    padding: 5px;
+    border-radius: 5px;
+    background-color: $brand-secondary;
+    color: white;
     text-align: center;
-    font-size: 14px;
+    font-weight: 400;
+    font-size: 13px;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      border-color: $brand-secondary transparent transparent transparent;
+    }
   }
 
-  .btn:not(.btn-inline) {
-    margin-top: 40px;
+  &:hover .tooltip-text {
+    visibility: visible;
   }
 }
 

--- a/app/styles/profile.scss
+++ b/app/styles/profile.scss
@@ -17,8 +17,6 @@
   @include align-items(baseline);
 
   h3 {
-    @include flex(1);
-
     margin: 0 0 8px;
     min-width: 0;
 
@@ -30,6 +28,10 @@
       padding-right: 15px;
       font-size: 20px;
     }
+  }
+
+  > a {
+    margin-left: auto;
   }
 }
 

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -156,42 +156,17 @@
         }
 
         .tooltip {
-          display: inline-block;
-          position: relative;
-          margin-left: 3px;
-
           .fa-plus-circle {
-            font-size: 11px;
+            color: white;
           }
 
           .tooltip-text {
-            visibility: hidden;
-            position: absolute;
-            bottom: 150%;
-            left: 50%;
-            margin-left: -($tooltip-width / 2);
-            z-index: 1;
-            width: $tooltip-width;
-            padding: 5px;
-            border-radius: 5px;
-            background-color: #fff;
             color: black;
-            text-align: center;
+            background-color: white;
 
             &::after {
-              content: "";
-              position: absolute;
-              top: 100%;
-              left: 50%;
-              margin-left: -5px;
-              border-width: 5px;
-              border-style: solid;
               border-color: #fff transparent transparent transparent;
             }
-          }
-
-          &:hover .tooltip-text {
-            visibility: visible;
           }
         }
       }

--- a/app/utils/pokemon.js
+++ b/app/utils/pokemon.js
@@ -5,12 +5,12 @@ export function htmlName (name) {
 }
 
 export function iconClass (id, shiny) {
-  const idPadded = padding(id, 3);
+  const paddedId = padding(id, 3);
 
   if (shiny) {
-    return `pkicon pkicon-${idPadded} color-shiny`;
+    return `pkicon pkicon-${paddedId} color-shiny`;
   }
-  return `pkicon pkicon-${idPadded} test`;
+  return `pkicon pkicon-${paddedId}`;
 }
 
 export function regionCheck (pokemon, region) {

--- a/app/utils/pokemon.js
+++ b/app/utils/pokemon.js
@@ -4,8 +4,13 @@ export function htmlName (name) {
   return { __html: name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>') };
 }
 
-export function iconClass (id) {
-  return `pkicon pkicon-${padding(id, 3)}`;
+export function iconClass (id, shiny) {
+  const idPadded = padding(id, 3);
+
+  if (shiny) {
+    return `pkicon pkicon-${idPadded} color-shiny`;
+  }
+  return `pkicon pkicon-${idPadded} test`;
 }
 
 export function regionCheck (pokemon, region) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -730,6 +730,21 @@
       "from": "buffer-shims@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
+    "bufferjs": {
+      "version": "3.0.1",
+      "from": "bufferjs@>=2.0.0",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz"
+    },
+    "bufferstream": {
+      "version": "0.6.2",
+      "from": "bufferstream@>=0.6.2",
+      "resolved": "https://registry.npmjs.org/bufferstream/-/bufferstream-0.6.2.tgz"
+    },
+    "buffertools": {
+      "version": "2.1.4",
+      "from": "buffertools@>=1.0.3",
+      "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.4.tgz"
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
@@ -3050,6 +3065,11 @@
       "from": "slice-ansi@0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
+    "slug": {
+      "version": "0.9.1",
+      "from": "slug@*",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz"
+    },
     "sntp": {
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
@@ -3344,6 +3364,11 @@
       "version": "1.0.2",
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "unicode": {
+      "version": "0.6.1",
+      "from": "unicode@>=0.3.1",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-0.6.1.tgz"
     },
     "uniq": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-router": "^2.8.1",
     "react-router-redux": "^4.0.6",
     "redux": "^3.6.0",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.1.0",
+    "slug": "^0.9.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
(੭ु´͈ ᐜ `͈)੭ु⁾⁾

### what
- add dex settings to signup
- use shiny sprites on tracker page if dex is shiny

### notes
- i added the dex stuff beneath the user stuff in one column, which i think is fine - but it's a bit weird when you submit the form and there's an error because you have to scroll back up to see the error. any way for us to auto-scroll up to the error? alternatively, i can refactor the register page to be two columns instead if you think that's better
- after registration, you get redirected to the profile page. do you think that's preferred or should we send you directly to your first dex?