### PR TITLE
refactor(dexes): use the dexes API for the tracker page

### DIFF
--- a/app/actions/capture.js
+++ b/app/actions/capture.js
@@ -5,37 +5,37 @@ import { checkVersion } from './utils';
 export const MARK_CAPTURED = 'MARK_CAPTURED';
 export const SET_CAPTURES  = 'SET_CAPTURES';
 
-export function createCaptures ({ payload, username }) {
+export function createCaptures ({ payload, slug, username }) {
   return (dispatch) => {
     dispatch(checkVersion());
 
     return API.post(`${Config.API_HOST}/captures`, payload)
-    .then(() => dispatch(markCaptured(true, payload.pokemon, username)));
+    .then(() => dispatch(markCaptured(true, payload.pokemon, slug, username)));
   };
 }
 
-export function deleteCaptures ({ payload, username }) {
+export function deleteCaptures ({ payload, slug, username }) {
   return (dispatch) => {
     dispatch(checkVersion());
 
     return API.delete(`${Config.API_HOST}/captures`, payload)
-    .then(() => dispatch(markCaptured(false, payload.pokemon, username)));
+    .then(() => dispatch(markCaptured(false, payload.pokemon, slug, username)));
   };
 }
 
-export function listCaptures ({ id, username }) {
+export function listCaptures ({ id, slug }, username) {
   return (dispatch) => {
     dispatch(checkVersion());
 
-    return API.get(`${Config.API_HOST}/captures`, { user: id })
-    .then((captures) => dispatch(setCaptures(captures, username)));
+    return API.get(`${Config.API_HOST}/captures`, { dex: id })
+    .then((captures) => dispatch(setCaptures(captures, slug, username)));
   };
 }
 
-export function setCaptures (captures, username) {
-  return { type: SET_CAPTURES, captures, username };
+export function setCaptures (captures, slug, username) {
+  return { type: SET_CAPTURES, captures, slug, username };
 }
 
-export function markCaptured (captured, pokemon, username) {
-  return { type: MARK_CAPTURED, captured, pokemon, username };
+export function markCaptured (captured, pokemon, slug, username) {
+  return { type: MARK_CAPTURED, captured, pokemon, slug, username };
 }

--- a/app/actions/dex.js
+++ b/app/actions/dex.js
@@ -1,0 +1,26 @@
+import { Config }       from '../../config';
+import { API }          from '../utils/api';
+import { checkVersion } from './utils';
+
+export const SET_DEX         = 'SET_DEX';
+export const SET_CURRENT_DEX = 'SET_CURRENT_DEX';
+
+export function retrieveDex (slug, username) {
+  return (dispatch) => {
+    dispatch(checkVersion());
+
+    return API.get(`${Config.API_HOST}/users/${username}/dexes/${slug}`)
+    .then((dex) => {
+      dispatch(setDex(dex, username));
+      return dex;
+    });
+  };
+}
+
+export function setCurrentDex (slug, username) {
+  return { type: SET_CURRENT_DEX, slug, username };
+}
+
+export function setDex (dex, username) {
+  return { type: SET_DEX, dex, username };
+}

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -3,7 +3,6 @@ import { push } from 'react-router-redux';
 import { Config }       from '../../config';
 import { API }          from '../utils/api';
 import { checkVersion } from './utils';
-import { listCaptures } from './capture';
 import { setToken }     from './session';
 
 export const SET_USER         = 'SET_USER';
@@ -33,7 +32,7 @@ export function retrieveUser (username) {
     return API.get(`${Config.API_HOST}/users/${username}`)
     .then((user) => {
       dispatch(setUser(user));
-      return dispatch(listCaptures(user));
+      return user;
     });
   };
 }
@@ -58,8 +57,8 @@ export function updateUser ({ username, payload }) {
   };
 }
 
-export function setCurrentUser (user) {
-  return { type: SET_CURRENT_USER, user };
+export function setCurrentUser (username) {
+  return { type: SET_CURRENT_USER, username };
 }
 
 export function setUser (user) {

--- a/app/components/dex.jsx
+++ b/app/components/dex.jsx
@@ -39,8 +39,8 @@ export class Dex extends Component {
   }
 }
 
-function mapStateToProps ({ currentUser, showScroll, users }) {
-  return { captures: users[currentUser].captures, showScroll };
+function mapStateToProps ({ currentDex, currentUser, showScroll, users }) {
+  return { captures: users[currentUser].dexesBySlug[currentDex].captures, showScroll };
 }
 
 function mapDispatchToProps (dispatch) {

--- a/app/components/mark-all-button.jsx
+++ b/app/components/mark-all-button.jsx
@@ -14,20 +14,20 @@ export class MarkAllButton extends Component {
   }
 
   toggleCaptured = () => {
-    const { captures, createCaptures, deleteCaptures, region, user } = this.props;
+    const { captures, createCaptures, currentDex, deleteCaptures, dex, region, user } = this.props;
     const deleting = captures.reduce((total, capture) => total + (!regionCheck(capture.pokemon, region) || capture.captured ? 0 : 1), 0) === 0;
     const pokemon = captures.filter((capture) => regionCheck(capture.pokemon, region) && capture.captured === deleting).map((capture) => capture.pokemon.national_id);
-    const payload = { pokemon };
+    const payload = { dex: dex.id, pokemon };
 
     Promise.resolve()
     .then(() => {
       this.setState({ loading: true });
 
       if (deleting) {
-        return deleteCaptures({ payload, username: user.username });
+        return deleteCaptures({ payload, slug: currentDex, username: user.username });
       }
 
-      return createCaptures({ payload, username: user.username });
+      return createCaptures({ payload, slug: currentDex, username: user.username });
     })
     .then(() => {
       const event = { category: 'Box', label: `${padding(captures[0].pokemon.national_id, 3)} - ${padding(captures[captures.length - 1].pokemon.national_id, 3)}` };
@@ -63,8 +63,8 @@ export class MarkAllButton extends Component {
 
 }
 
-function mapStateToProps ({ currentUser, region, session, users }) {
-  return { region, session, user: users[currentUser] };
+function mapStateToProps ({ currentDex, currentUser, region, session, users }) {
+  return { currentDex, dex: users[currentUser].dexesBySlug[currentDex], region, session, user: users[currentUser] };
 }
 
 function mapDispatchToProps (dispatch) {

--- a/app/components/pokemon.jsx
+++ b/app/components/pokemon.jsx
@@ -23,20 +23,20 @@ export class Pokemon extends Component {
   }
 
   toggleCaptured = () => {
-    const { capture, createCaptures, deleteCaptures, region, session, user } = this.props;
+    const { capture, createCaptures, currentDex, deleteCaptures, dex, region, session, user } = this.props;
 
     if (!session || session.id !== user.id || !regionCheck(capture.pokemon, region)) {
       return;
     }
 
-    const payload = { pokemon: [capture.pokemon.national_id] };
+    const payload = { dex: dex.id, pokemon: [capture.pokemon.national_id] };
 
     Promise.resolve()
     .then(() => {
       if (capture.captured) {
-        deleteCaptures({ payload, username: user.username });
+        deleteCaptures({ payload, slug: currentDex, username: user.username });
       } else {
-        createCaptures({ payload, username: user.username });
+        createCaptures({ payload, slug: currentDex, username: user.username });
       }
     })
     .then(() => {
@@ -90,8 +90,8 @@ export class Pokemon extends Component {
 
 }
 
-function mapStateToProps ({ currentUser, region, session, users }) {
-  return { region, session, user: users[currentUser] };
+function mapStateToProps ({ currentDex, currentUser, region, session, users }) {
+  return { currentDex, dex: users[currentUser].dexesBySlug[currentDex], region, session, user: users[currentUser] };
 }
 
 function mapDispatchToProps (dispatch) {

--- a/app/components/progress.jsx
+++ b/app/components/progress.jsx
@@ -19,8 +19,8 @@ export function Progress ({ captures, region }) {
   );
 }
 
-function mapStateToProps ({ currentUser, region, users }) {
-  return { captures: users[currentUser].captures, region };
+function mapStateToProps ({ currentDex, currentUser, region, users }) {
+  return { captures: users[currentUser].dexesBySlug[currentDex].captures, region };
 }
 
 export const ProgressComponent = connect(mapStateToProps)(Progress);

--- a/app/components/tracker.jsx
+++ b/app/components/tracker.jsx
@@ -2,15 +2,17 @@ import { Component } from 'react';
 import DocumentTitle from 'react-document-title';
 import { connect }   from 'react-redux';
 
-import { DexComponent }                 from './dex';
-import { InfoComponent }                from './info';
-import { NavComponent }                 from './nav';
-import { NotFoundComponent }            from './not-found';
-import { ReloadComponent }              from './reload';
-import { checkVersion }                 from '../actions/utils';
-import { retrieveUser, setCurrentUser } from '../actions/user';
-import { setCurrentPokemon }            from '../actions/pokemon';
-import { setShowScroll }                from '../actions/tracker';
+import { DexComponent }               from './dex';
+import { InfoComponent }              from './info';
+import { NavComponent }               from './nav';
+import { NotFoundComponent }          from './not-found';
+import { ReloadComponent }            from './reload';
+import { checkVersion }               from '../actions/utils';
+import { listCaptures }               from '../actions/capture';
+import { retrieveDex, setCurrentDex } from '../actions/dex';
+import { retrieveUser }               from '../actions/user';
+import { setCurrentPokemon }          from '../actions/pokemon';
+import { setShowScroll }              from '../actions/tracker';
 
 export class Tracker extends Component {
 
@@ -30,15 +32,19 @@ export class Tracker extends Component {
   }
 
   reset () {
-    const { checkVersion, params: { username }, retrieveUser, setCurrentPokemon, setCurrentUser, setShowScroll } = this.props;
+    const { checkVersion, listCaptures, params: { username }, retrieveDex, retrieveUser, setCurrentDex, setCurrentPokemon, setShowScroll } = this.props;
+    const slug = 'living-dex';
 
     this.setState({ ...this.state, loading: true });
 
     checkVersion();
     setShowScroll(false);
     setCurrentPokemon(1);
-    setCurrentUser(username);
+    setCurrentDex(slug, username);
+
     retrieveUser(username)
+    .then(() => retrieveDex(slug, username))
+    .then((dex) => listCaptures(dex, username))
     .then(() => this.setState({ ...this.state, loading: false }))
     .catch(() => this.setState({ ...this.state, loading: false }));
   }
@@ -82,9 +88,11 @@ function mapStateToProps ({ users }, { params: { username } }) {
 function mapDispatchToProps (dispatch) {
   return {
     checkVersion: () => dispatch(checkVersion()),
+    listCaptures: (dex, username) => dispatch(listCaptures(dex, username)),
+    retrieveDex: (slug, username) => dispatch(retrieveDex(slug, username)),
     retrieveUser: (username) => dispatch(retrieveUser(username)),
     setCurrentPokemon: (id) => dispatch(setCurrentPokemon(id)),
-    setCurrentUser: (username) => dispatch(setCurrentUser(username)),
+    setCurrentDex: (slug, username) => dispatch(setCurrentDex(slug, username)),
     setShowScroll: (show) => dispatch(setShowScroll(show))
   };
 }

--- a/app/reducers/captures.js
+++ b/app/reducers/captures.js
@@ -7,7 +7,12 @@ export function captures (state = {}, action) {
         ...state,
         [action.username]: {
           ...state[action.username],
-          captures: action.captures
+          dexesBySlug: {
+            [action.slug]: {
+              ...state[action.username].dexesBySlug[action.slug],
+              captures: action.captures
+            }
+          }
         }
       };
     case MARK_CAPTURED:
@@ -15,10 +20,15 @@ export function captures (state = {}, action) {
         ...state,
         [action.username]: {
           ...state[action.username],
-          captures: state[action.username].captures.slice()
+          dexesBySlug: {
+            [action.slug]: {
+              ...state[action.username].dexesBySlug[action.slug],
+              captures: state[action.username].dexesBySlug[action.slug].captures.slice()
+            }
+          }
         }
       };
-      action.pokemon.forEach((pokemon) => newState[action.username].captures[pokemon - 1].captured = action.captured);
+      action.pokemon.forEach((pokemon) => newState[action.username].dexesBySlug[action.slug].captures[pokemon - 1].captured = action.captured);
       return newState;
     default:
       return state;

--- a/app/reducers/current-dex.js
+++ b/app/reducers/current-dex.js
@@ -1,0 +1,10 @@
+import { SET_CURRENT_DEX } from '../actions/dex';
+
+export function currentDex (state = null, action) {
+  switch (action.type) {
+    case SET_CURRENT_DEX:
+      return action.slug;
+    default:
+      return state;
+  }
+}

--- a/app/reducers/current-user.js
+++ b/app/reducers/current-user.js
@@ -1,9 +1,11 @@
+import { SET_CURRENT_DEX }  from '../actions/dex';
 import { SET_CURRENT_USER } from '../actions/user';
 
 export function currentUser (state = null, action) {
   switch (action.type) {
+    case SET_CURRENT_DEX:
     case SET_CURRENT_USER:
-      return action.user;
+      return action.username;
     default:
       return state;
   }

--- a/app/reducers/dexes.js
+++ b/app/reducers/dexes.js
@@ -1,0 +1,27 @@
+import { SET_DEX }                     from '../actions/dex';
+import { MARK_CAPTURED, SET_CAPTURES } from '../actions/capture';
+import { captures }                    from '../reducers/captures';
+
+export function dexes (state = {}, action) {
+  switch (action.type) {
+    case SET_DEX:
+      return {
+        ...state,
+        [action.username]: {
+          ...state[action.username],
+          dexesBySlug: {
+            ...state[action.username].dexesBySlug,
+            [action.dex.slug]: {
+              ...action.dex,
+              captures: []
+            }
+          }
+        }
+      };
+    case SET_CAPTURES:
+    case MARK_CAPTURED:
+      return captures(state, action);
+    default:
+      return state;
+  }
+}

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import { routerReducer }   from 'react-router-redux';
 
+import { currentDex }     from './current-dex';
 import { currentPokemon } from './current-pokemon';
 import { currentUser }    from './current-user';
 import { pokemon }        from './pokemon';
@@ -14,6 +15,7 @@ import { token }          from './token';
 import { users }          from './users';
 
 export const reducer = combineReducers({
+  currentDex,
   currentPokemon,
   currentUser,
   pokemon,

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -1,6 +1,7 @@
 import { MARK_CAPTURED, SET_CAPTURES } from '../actions/capture';
+import { SET_DEX }                     from '../actions/dex';
 import { SET_USER }                    from '../actions/user';
-import { captures }                    from '../reducers/captures';
+import { dexes }                       from '../reducers/dexes';
 
 export function users (state = {}, action) {
   switch (action.type) {
@@ -9,12 +10,13 @@ export function users (state = {}, action) {
         ...state,
         [action.user.username]: {
           ...action.user,
-          captures: []
+          dexesBySlug: {}
         }
       };
     case MARK_CAPTURED:
     case SET_CAPTURES:
-      return captures(state, action);
+    case SET_DEX:
+      return dexes(state, action);
     default:
       return state;
   }


### PR DESCRIPTION
(ꐦ°᷄д°᷅)

this is the same commit from #199, but merging to master instead of the feature branch, except it's also passing `dex` when saving/deleting captures. as i was testing #203, i created a shiny dex for `/u/hiami` which was the third dex for that account but every time i marked a pokemon as captured, it didnt actually mark it as captured in the db. this is cause the endpoint just picks a random dexs to create the captures for lol. but for the api to use a dex id thats being passed in, this needs to be in master.

you should just make sure that everything still works as expected (particularly users with only one dex)!