### PR TITLE
refactor(info): generate urls on the front-end and add spaces

### DIFF
--- a/app/components/evolutions.jsx
+++ b/app/components/evolutions.jsx
@@ -7,13 +7,13 @@ export function EvolutionsComponent ({ evolutions }) {
 
     switch (evolution.trigger) {
       case 'level':
-        trigger = <span>Level Up {evolution.level ? `to ${evolution.level}` : ''}</span>;
+        trigger = <span>Level Up {evolution.level ? `to ${evolution.level} ` : ''}</span>;
         break;
       case 'stone':
-        trigger = <span>{capitalize(evolution.stone)} Stone</span>;
+        trigger = <span>{capitalize(evolution.stone)} Stone </span>;
         break;
       default:
-        trigger = <span>{capitalize(evolution.trigger)}</span>;
+        trigger = <span>{capitalize(evolution.trigger)} </span>;
     }
 
     if (evolution.notes) {
@@ -34,7 +34,7 @@ export function EvolutionsComponent ({ evolutions }) {
         <i className={`fa ${evolution.trigger === 'breed' ? 'fa-long-arrow-left' : 'fa-long-arrow-right'}`} />
         <div>
           {trigger}
-          {evolution.held_item ? <span>holding {capitalize(evolution.held_item)}</span> : null}
+          {evolution.held_item ? <span>holding {capitalize(evolution.held_item)} </span> : null}
           {notes}
         </div>
       </div>

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -84,8 +84,8 @@ export class Info extends Component {
           <EvolutionFamilyComponent family={pokemon.evolution_family} />
 
           <div className="info-footer">
-            <a href={pokemon.bulbapedia_url} target="_blank" onClick={() => ReactGA.event({ action: 'open Bulbapedia link', category: 'Info', label: pokemon.name })}>Bulbapedia <i className="fa fa-long-arrow-right" /></a>
-            <a href={pokemon.serebii_url} target="_blank" onClick={() => ReactGA.event({ action: 'open Serebii link', category: 'Info', label: pokemon.name })}>Serebii <i className="fa fa-long-arrow-right" /></a>
+            <a href={`http://bulbapedia.bulbagarden.net/wiki/${encodeURIComponent(pokemon.name)}_(Pok%C3%A9mon)`} target="_blank" onClick={() => ReactGA.event({ action: 'open Bulbapedia link', category: 'Info', label: pokemon.name })}>Bulbapedia <i className="fa fa-long-arrow-right" /></a>
+            <a href={`http://www.serebii.net/pokedex-xy/${padding(pokemon.national_id, 3)}.shtml`} target="_blank" onClick={() => ReactGA.event({ action: 'open Serebii link', category: 'Info', label: pokemon.name })}>Serebii <i className="fa fa-long-arrow-right" /></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
(⋆ॢʾ ˙̫̮ ʿ⋆ॢ)

stop relying on the returned props so that we can generate them based on dex. this is necessary for gen vii support. this is blocking https://github.com/robinjoseph08/api.pokedextracker.com/pull/69 so we should deploy this as soon as its merged!

i also noticed that we were missing some spaces. some examples of why we need it:

![image](https://cloud.githubusercontent.com/assets/2454505/20470887/a4e54a3c-af61-11e6-87c0-f77326cac07e.png)

![image](https://cloud.githubusercontent.com/assets/2454505/20470895/b94bbe5c-af61-11e6-942a-96449d3b4825.png)

![image](https://cloud.githubusercontent.com/assets/2454505/20470906/cc7a7a18-af61-11e6-84bc-24e82e2d7629.png)

i dont think adding these spaces will hurt if they arent needed, right?